### PR TITLE
ci: 添加 Unity Package 编译矩阵

### DIFF
--- a/.github/workflows/unity-package-compile.yml
+++ b/.github/workflows/unity-package-compile.yml
@@ -1,0 +1,80 @@
+name: Unity Package Compile Matrix
+
+"on":
+  workflow_dispatch:
+  push:
+    branches:
+      - beta
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  editmode:
+    name: Unity ${{ matrix.unityVersion }} EditMode
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - unityVersion: 2022.3.62f1
+            uguiVersion: 1.0.0
+          - unityVersion: 6000.0.76f1
+            uguiVersion: 2.0.0
+          - unityVersion: 6000.2.0f1
+            uguiVersion: 2.0.0
+          - unityVersion: 6000.3.18f1
+            uguiVersion: 2.0.0
+          - unityVersion: 6000.4.12f1
+            uguiVersion: 2.0.0
+          - unityVersion: 6000.5.0f1
+            uguiVersion: 2.5.0
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Create CI test project
+        run: |
+          set -euo pipefail
+          mkdir -p TempUnityProject/Assets TempUnityProject/Packages TempUnityProject/ProjectSettings
+          cat > TempUnityProject/Packages/manifest.json <<EOF
+          {
+            "dependencies": {
+              "com.unity.test-framework": "1.4.5",
+              "com.unity.testtools.codecoverage": "1.3.0",
+              "com.unity.ugui": "${{ matrix.uguiVersion }}",
+              "com.besty.unity-skills": "file:../../SkillsForUnity"
+            },
+            "testables": [
+              "com.besty.unity-skills"
+            ]
+          }
+          EOF
+          cat > TempUnityProject/ProjectSettings/ProjectVersion.txt <<EOF
+          m_EditorVersion: ${{ matrix.unityVersion }}
+          EOF
+          cat TempUnityProject/Packages/manifest.json
+
+      - uses: game-ci/unity-test-runner@v4
+        id: tests
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          packageMode: false
+          projectPath: TempUnityProject
+          unityVersion: ${{ matrix.unityVersion }}
+          testMode: EditMode
+          artifactsPath: artifacts/${{ matrix.unityVersion }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unity-test-results-${{ matrix.unityVersion }}
+          path: ${{ steps.tests.outputs.artifactsPath }}


### PR DESCRIPTION
## 说明

按照下面的配置就可以跑了，目前取得了跑通5个的好成绩。6000.5.0f1的修复比想象中麻烦一点。

---
以下为AI生成
---

## CI Secrets 配置

该 workflow 使用 GameCI 运行 Unity，需要在 GitHub 仓库中配置以下 3 个 Actions Secrets：

- `UNITY_LICENSE`
- `UNITY_EMAIL`
- `UNITY_PASSWORD`

配置路径：

1. 打开 GitHub 仓库页面
2. 进入 `Settings`
3. 进入 `Secrets and variables`
4. 选择 `Actions`
5. 进入 `Secrets` 标签页
6. 点击 `New repository secret`
7. 分别添加以下 3 个 secret

### UNITY_LICENSE

`UNITY_LICENSE` 填 Unity license 文件的完整内容。

Windows 常见路径：

```text
C:\ProgramData\Unity\Unity_lic.ulf
```

打开该文件后，复制完整 XML 内容，粘贴到 `UNITY_LICENSE`。

### UNITY_EMAIL

`UNITY_EMAIL` 填 Unity 账号邮箱。

### UNITY_PASSWORD

`UNITY_PASSWORD` 填 Unity 账号密码。

注意：这三个值都应该配置为 **Secrets**，不要配置为 Variables。Secrets 会被 GitHub 加密保存，并且在日志中自动隐藏。

---

## PR概要

新增 Unity Package 编译矩阵 CI，用于验证该 package 在 Unity 2022.3 和 Unity 6000.x 下的 EditMode 编译与测试情况。

## 变更内容

- 新增 `.github/workflows/unity-package-compile.yml`
- 覆盖以下 Unity 版本：
  - Unity 2022.3.62f1
  - Unity 6000.0.76f1
  - Unity 6000.2.0f1
  - Unity 6000.3.18f1
  - Unity 6000.4.12f1
  - Unity 6000.5.0f1
- CI 中临时创建 Unity 项目，并通过本地 `file:` 依赖安装当前 package。
- 在 CI 临时项目中补充 UGUI 和 Code Coverage 依赖，不修改正式的 `SkillsForUnity/package.json`。

## 验证结果

当前 CI 结果：

- Unity 2022.3 到 Unity 6000.4 的 EditMode 测试通过。
- Unity 6000.5 会暴露项目中剩余的 obsolete API 编译错误，包括：
  - `GetInstanceID`
  - `EditorUtility.InstanceIDToObject`
  - `Selection.instanceIDs`
  - `SerializedProperty.objectReferenceInstanceIDValue`

该 workflow 的目的，是先让 Unity 6000.5 的兼容性问题能在 CI 中稳定暴露，方便后续继续处理 API 迁移。
<img width="1604" height="1230" alt="image" src="https://github.com/user-attachments/assets/8765f308-d2fd-4065-811c-8de03f7c0881" />
