### PR TITLE
fix: 兼容 Unity 6000.5 EntityId 对象定位

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to **UnitySkills** will be documented in this file.
 
+## [2.0.4] - 2026-06-18
+
+### Changed
+
+- **Unity 对象 ID 兼容层** — 新增 `UnityObjectIdUtility`，统一封装 `EntityId`、legacy `InstanceID`、对象查找、缺失引用检测与 Selection 读写逻辑；Unity 6000.5 走 EntityId 路径，旧版本保留 InstanceID fallback。
+- **Unity 6000.x API 对齐** — 更新 PlayerSettings、Shader、FindObjectsByType、UI Toolkit 背景样式等 API 用法，减少 Unity 6000.5 obsolete warning。
+- **版本号更新** — `SkillsLogger.Version` / `package.json` / Python helper `__version__` / `agent.md` / README 当前版本标记同步提升到 `2.0.4`。
+
+### Fixed
+
+- **Unity 6000.5 编译兼容** — 替换业务代码中的 `GetInstanceID`、`EditorUtility.InstanceIDToObject`、`objectReferenceInstanceIDValue`、`Selection.instanceIDs` 等 obsolete API 入口，避免 warning-as-error 下编译失败。
+- **批处理模型序列化告警** — 移除 BatchModels 的 Unity 序列化标记，避免 Newtonsoft 持久化模型触发 UAC1009。
+- **对象定位与工作流选择恢复** — 批量查询/执行、GameObject 查找、Workflow bookmark 与 snapshot 支持 `entityId`，保留 legacy `instanceId` 兼容路径。
+
 ## [2.0.3] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is a deep refactoring and feature extension based on the excellent 
 ## 🚀 Core Features
 
 - 🛠️ **750 REST Skills Comprehensive Toolkit**: Includes 51 functional source modules plus 19 advisory design modules, with Batch operations for multi-object control.
-- ⚡ **Revolutionary Efficiency Boost (v2.0.1+)**: Schema caching + exponential backoff polling + BATCH-FIRST guidance → **Token consumption ↓ 96%**, **simple tasks 4-6 calls → 1 call (↓ 75-83%)**. Current: v2.0.3.
+- ⚡ **Revolutionary Efficiency Boost (v2.0.1+)**: Schema caching + exponential backoff polling + BATCH-FIRST guidance → **Token consumption ↓ 96%**, **simple tasks 4-6 calls → 1 call (↓ 75-83%)**. Current: v2.0.4.
 - 🔐 **Three-Tier Permission Modes (v1.9.0+)**: Approval / Auto / Bypass with dual approval channels (Dialog / Panel), aligned with Claude Code permission modes; zero-impact upgrade for existing users.
 - 🤖 **4 Major IDEs Native Support**: Claude Code / Antigravity / Codex / Cursor — one-click install and use.
 - 🛡️ **Transactional Atomicity**: Failed operations auto-rollback, leaving scenes clean and safe.

--- a/README_CN.md
+++ b/README_CN.md
@@ -31,7 +31,7 @@
 ## 🚀 核心特性
 
 - 🛠️ **750 REST Skills 全能库**：包含 51 个功能源码模块和 19 个 advisory 设计模块，支持 Batch 批处理，一次操控多个对象。
-- ⚡ **调用效率革命性提升 (v2.0.1+)**：Schema 缓存 + 指数退避轮询 + BATCH-FIRST 引导 → **Token 消耗 ↓ 96%**，**简单任务 4-6 次调用 → 1 次（↓ 75-83%）**。当前：v2.0.3。
+- ⚡ **调用效率革命性提升 (v2.0.1+)**：Schema 缓存 + 指数退避轮询 + BATCH-FIRST 引导 → **Token 消耗 ↓ 96%**，**简单任务 4-6 次调用 → 1 次（↓ 75-83%）**。当前：v2.0.4。
 - 🔐 **三档权限模式 (v1.9.0+)**：Approval / Auto / Bypass，配合双轨审批渠道（Dialog / Panel），对齐 Claude Code permission modes；老用户升级零感知。
 - 🤖 **4 大 IDE 原生支持**：Claude Code / Antigravity / Codex / Cursor，一键安装即用。
 - 🛡️ **事务原子性保障**：操作失败自动回滚，场景永不残留，确保流程安全。

--- a/SkillsForUnity/Editor/Skills/AnimatorSkills.cs
+++ b/SkillsForUnity/Editor/Skills/AnimatorSkills.cs
@@ -202,7 +202,8 @@ namespace UnitySkills
             return new
             {
                 gameObject = animator.gameObject.name,
-                instanceId = animator.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(animator.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(animator.gameObject),
                 hasController = animator.runtimeAnimatorController != null,
                 controllerPath,
                 speed = animator.speed,

--- a/SkillsForUnity/Editor/Skills/AudioSkills.cs
+++ b/SkillsForUnity/Editor/Skills/AudioSkills.cs
@@ -258,7 +258,7 @@ namespace UnitySkills
                 if (clip != null) source.clip = clip;
             }
 
-            return new { success = true, gameObject = go.name, instanceId = go.GetInstanceID() };
+            return new { success = true, gameObject = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go) };
         }
 
         [UnitySkill("audio_get_source_info", "Get AudioSource configuration",

--- a/SkillsForUnity/Editor/Skills/BatchModels.cs
+++ b/SkillsForUnity/Editor/Skills/BatchModels.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 
 namespace UnitySkills
 {
-    [Serializable]
     internal class BatchTargetQuery
     {
         public string name;
         public string namePattern;
         public string path;
+        public string entityId;
         public int instanceId;
         public string tag;
         public string layer;
@@ -22,12 +22,12 @@ namespace UnitySkills
         public int limit = 500;
     }
 
-    [Serializable]
     internal class BatchPreviewItem
     {
         public string action;
         public string targetName;
         public string targetPath;
+        public string entityId;
         public int instanceId;
         public string sceneName;
         public string componentType;
@@ -47,7 +47,6 @@ namespace UnitySkills
         public string skipReason;
     }
 
-    [Serializable]
     internal class BatchPreviewEnvelope
     {
         public string confirmToken;
@@ -66,14 +65,12 @@ namespace UnitySkills
         public int skipCount;
     }
 
-    [Serializable]
     internal class BatchFailureGroup
     {
         public string reason;
         public int count;
     }
 
-    [Serializable]
     internal class BatchReportTotals
     {
         public int total;
@@ -82,11 +79,11 @@ namespace UnitySkills
         public int skipped;
     }
 
-    [Serializable]
     internal class BatchReportItemRecord
     {
         public string targetName;
         public string targetPath;
+        public string entityId;
         public int instanceId;
         public string action;
         public string status;
@@ -97,7 +94,6 @@ namespace UnitySkills
         public int chunkIndex;
     }
 
-    [Serializable]
     internal class BatchReportRecord
     {
         public string reportId;
@@ -115,7 +111,6 @@ namespace UnitySkills
         public List<BatchFailureGroup> failureGroups = new List<BatchFailureGroup>();
     }
 
-    [Serializable]
     internal class BatchJobLogEntry
     {
         public long timestamp;
@@ -125,7 +120,6 @@ namespace UnitySkills
         public string code;
     }
 
-    [Serializable]
     internal class BatchJobRecord
     {
         public string jobId;
@@ -154,7 +148,6 @@ namespace UnitySkills
         public List<BatchJobProgressEvent> progressEvents = new List<BatchJobProgressEvent>();
     }
 
-    [Serializable]
     internal class BatchJobProgressEvent
     {
         public long timestamp;
@@ -163,7 +156,6 @@ namespace UnitySkills
         public string description;
     }
 
-    [Serializable]
     internal class BatchStorageState
     {
         public List<BatchPreviewEnvelope> previews = new List<BatchPreviewEnvelope>();

--- a/SkillsForUnity/Editor/Skills/BatchSkills.cs
+++ b/SkillsForUnity/Editor/Skills/BatchSkills.cs
@@ -16,7 +16,7 @@ namespace UnitySkills
         private static readonly Regex MultiWhitespaceRegex = new Regex(@"\s+", RegexOptions.Compiled);
         private static readonly Regex MultiUnderscoreRegex = new Regex(@"_+", RegexOptions.Compiled);
 
-        [UnitySkill("batch_query_gameobjects", "Query GameObjects with unified batch filters. queryJson supports name/path/instanceId/tag/layer/active/componentType/sceneName/parentPath/prefabSource/includeInactive/limit.",
+        [UnitySkill("batch_query_gameobjects", "Query GameObjects with unified batch filters. queryJson supports name/path/entityId/instanceId/tag/layer/active/componentType/sceneName/parentPath/prefabSource/includeInactive/limit.",
             Category = SkillCategory.Workflow, Operation = SkillOperation.Query,
             Tags = new[] { "batch", "query", "gameobject", "filter" },
             Outputs = new[] { "count", "objects", "summary" },
@@ -46,7 +46,8 @@ namespace UnitySkills
             var objects = targets.Take(Math.Max(1, sampleLimit)).Select(go => new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetCachedPath(go),
                 components = go.GetComponents<Component>().Where(component => component != null).Select(component => component.GetType().Name).ToArray()
             }).ToArray();
@@ -591,6 +592,7 @@ namespace UnitySkills
                     action = fi.action ?? report.kind,
                     targetName = fi.targetName,
                     targetPath = fi.targetPath,
+                    entityId = fi.entityId,
                     instanceId = fi.instanceId,
                     willChange = true,
                     valid = true
@@ -650,6 +652,7 @@ namespace UnitySkills
                     {
                         targetName = item.targetName,
                         targetPath = item.targetPath,
+                        entityId = item.entityId,
                         instanceId = item.instanceId,
                         action = item.action,
                         status = "failed",
@@ -754,8 +757,10 @@ namespace UnitySkills
 
             if (!query.includeInactive)
                 results = results.Where(go => go.activeInHierarchy);
+            if (!string.IsNullOrWhiteSpace(query.entityId))
+                results = results.Where(go => UnityObjectIdUtility.MatchesEntityId(go, query.entityId));
             if (query.instanceId != 0)
-                results = results.Where(go => go.GetInstanceID() == query.instanceId);
+                results = results.Where(go => UnityObjectIdUtility.MatchesObjectId(go, query.instanceId));
             if (!string.IsNullOrWhiteSpace(query.path))
                 results = results.Where(go => string.Equals(GameObjectFinder.GetCachedPath(go), query.path.Trim(), StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrWhiteSpace(query.name))
@@ -853,7 +858,8 @@ namespace UnitySkills
                     action = "rename",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     currentValue = target.name,
                     nextValue = nextName,
@@ -930,7 +936,8 @@ namespace UnitySkills
                     action = "set_property",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     componentType = componentType,
                     propertyName = propertyName,
@@ -978,7 +985,8 @@ namespace UnitySkills
                     action = "replace_material",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     currentMaterialPath = currentPath,
                     nextMaterialPath = materialPath,
@@ -1005,7 +1013,8 @@ namespace UnitySkills
                     action = "remove_missing_scripts",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     currentValue = missingCount.ToString(),
                     nextValue = "0",
@@ -1038,7 +1047,8 @@ namespace UnitySkills
                     action = "rename",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     currentValue = target.name,
                     nextValue = standardized,
@@ -1078,7 +1088,8 @@ namespace UnitySkills
                     action = "set_layer",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     currentLayer = currentLayer,
                     nextLayer = layer,
@@ -1108,7 +1119,8 @@ namespace UnitySkills
                     action = "delete_gameobject",
                     targetName = target.name,
                     targetPath = GameObjectFinder.GetCachedPath(target),
-                    instanceId = target.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(target),
+                    instanceId = UnityObjectIdUtility.GetObjectId(target),
                     sceneName = target.scene.name,
                     reason = $"matched_pattern:{matchedPattern}",
                     willChange = true
@@ -1128,6 +1140,7 @@ namespace UnitySkills
             {
                 item.targetName,
                 item.targetPath,
+                item.entityId,
                 item.action,
                 before = ChooseBeforeValue(item),
                 after = ChooseAfterValue(item)
@@ -1189,7 +1202,8 @@ namespace UnitySkills
                 action = action,
                 targetName = target.name,
                 targetPath = GameObjectFinder.GetCachedPath(target),
-                instanceId = target.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(target),
+                instanceId = UnityObjectIdUtility.GetObjectId(target),
                 sceneName = target.scene.name,
                 currentValue = currentValue,
                 nextValue = nextValue,
@@ -1245,7 +1259,8 @@ namespace UnitySkills
             return new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetCachedPath(go),
                 scene = go.scene.name,
                 tag = go.tag,
@@ -1324,7 +1339,7 @@ namespace UnitySkills
 
         private static GameObject FindTarget(BatchPreviewItem item)
         {
-            return GameObjectFinder.Find(item.targetName, item.instanceId, item.targetPath);
+            return GameObjectFinder.Find(item.targetName, item.instanceId, item.targetPath, entityId: item.entityId);
         }
 
         private static BatchReportItemRecord ExecuteRenameItem(BatchPreviewItem item, int chunkIndex)
@@ -1425,6 +1440,7 @@ namespace UnitySkills
             {
                 targetName = item.targetName,
                 targetPath = item.targetPath,
+                entityId = item.entityId,
                 instanceId = item.instanceId,
                 action = item.action,
                 status = "success",
@@ -1451,17 +1467,17 @@ namespace UnitySkills
 
         private static BatchReportItemRecord CreateSuccessReport(BatchPreviewItem item, int chunkIndex, string before, string after)
         {
-            return new BatchReportItemRecord { targetName = item.targetName, targetPath = item.targetPath, instanceId = item.instanceId, action = item.action, status = "success", before = before, after = after, chunkIndex = chunkIndex };
+            return new BatchReportItemRecord { targetName = item.targetName, targetPath = item.targetPath, entityId = item.entityId, instanceId = item.instanceId, action = item.action, status = "success", before = before, after = after, chunkIndex = chunkIndex };
         }
 
         private static BatchReportItemRecord CreateSkippedReport(BatchPreviewItem item, int chunkIndex, string reason)
         {
-            return new BatchReportItemRecord { targetName = item.targetName, targetPath = item.targetPath, instanceId = item.instanceId, action = item.action, status = "skipped", before = ChooseBeforeValue(item), after = ChooseAfterValue(item), reason = reason, chunkIndex = chunkIndex };
+            return new BatchReportItemRecord { targetName = item.targetName, targetPath = item.targetPath, entityId = item.entityId, instanceId = item.instanceId, action = item.action, status = "skipped", before = ChooseBeforeValue(item), after = ChooseAfterValue(item), reason = reason, chunkIndex = chunkIndex };
         }
 
         private static BatchReportItemRecord CreateFailedReport(BatchPreviewItem item, int chunkIndex, string reason)
         {
-            return new BatchReportItemRecord { targetName = item.targetName, targetPath = item.targetPath, instanceId = item.instanceId, action = item.action, status = "failed", before = ChooseBeforeValue(item), after = ChooseAfterValue(item), reason = reason, chunkIndex = chunkIndex };
+            return new BatchReportItemRecord { targetName = item.targetName, targetPath = item.targetPath, entityId = item.entityId, instanceId = item.instanceId, action = item.action, status = "failed", before = ChooseBeforeValue(item), after = ChooseAfterValue(item), reason = reason, chunkIndex = chunkIndex };
         }
 
         private static string ChooseBeforeValue(BatchPreviewItem item)

--- a/SkillsForUnity/Editor/Skills/CameraSkills.cs
+++ b/SkillsForUnity/Editor/Skills/CameraSkills.cs
@@ -104,7 +104,7 @@ namespace UnitySkills
             go.transform.position = new Vector3(x, y, z);
             Undo.RegisterCreatedObjectUndo(go, "Create Camera");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID() };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go) };
         }
 
         [UnitySkill("camera_get_properties", "Get Game Camera properties (supports name/instanceId/path)",
@@ -378,7 +378,9 @@ namespace UnitySkills
             var cameras = FindHelper.FindAll<Camera>();
             var list = cameras.Select(c => new
             {
-                name = c.gameObject.name, instanceId = c.gameObject.GetInstanceID(),
+                name = c.gameObject.name,
+                entityId = UnityObjectIdUtility.GetEntityId(c.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(c.gameObject),
                 path = GameObjectFinder.GetPath(c.gameObject),
                 depth = c.depth, orthographic = c.orthographic, enabled = c.enabled
             }).OrderBy(c => c.depth).ToArray();

--- a/SkillsForUnity/Editor/Skills/CinemachineSkills.cs
+++ b/SkillsForUnity/Editor/Skills/CinemachineSkills.cs
@@ -56,7 +56,7 @@ namespace UnitySkills
                 }
             }
 
-            return new { success = true, gameObjectName = go.name, instanceId = go.GetInstanceID() };
+            return new { success = true, gameObjectName = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go) };
 #endif
         }
 
@@ -1177,7 +1177,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Sequencer Camera");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, gameObjectName = go.name, instanceId = go.GetInstanceID(), type = CinemachineAdapter.SequencerTypeName, loop };
+            return new { success = true, gameObjectName = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), type = CinemachineAdapter.SequencerTypeName, loop };
 #endif
         }
 
@@ -1273,7 +1273,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create FreeLook Camera");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, gameObjectName = go.name, instanceId = go.GetInstanceID() };
+            return new { success = true, gameObjectName = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go) };
 #endif
         }
 

--- a/SkillsForUnity/Editor/Skills/CleanerSkills.cs
+++ b/SkillsForUnity/Editor/Skills/CleanerSkills.cs
@@ -203,7 +203,7 @@ namespace UnitySkills
                     {
                         if (prop.propertyType == SerializedPropertyType.ObjectReference)
                         {
-                            if (prop.objectReferenceValue == null && prop.objectReferenceInstanceIDValue != 0)
+                            if (UnityObjectIdUtility.HasMissingObjectReference(prop))
                             {
                                 issues.Add(new
                                 {

--- a/SkillsForUnity/Editor/Skills/ComponentSkills.cs
+++ b/SkillsForUnity/Editor/Skills/ComponentSkills.cs
@@ -81,7 +81,8 @@ namespace UnitySkills
                 return new { 
                     warning = $"Component {type.Name} already exists on {go.name}",
                     gameObject = go.name,
-                    instanceId = go.GetInstanceID()
+                    entityId = UnityObjectIdUtility.GetEntityId(go),
+                    instanceId = UnityObjectIdUtility.GetObjectId(go)
                 };
 
             var comp = Undo.AddComponent(go, type);
@@ -97,7 +98,8 @@ namespace UnitySkills
             return new {
                 success = true,
                 gameObject = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 component = type.Name,
                 fullTypeName = type.FullName
             };
@@ -265,12 +267,13 @@ namespace UnitySkills
                 })
                 .ToArray();
 
-            return new { 
-                gameObject = go.name, 
-                instanceId = go.GetInstanceID(), 
-                path = GameObjectFinder.GetPath(go), 
+            return new {
+                gameObject = go.name,
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
+                path = GameObjectFinder.GetPath(go),
                 componentCount = components.Length,
-                components 
+                components
             };
         }
 

--- a/SkillsForUnity/Editor/Skills/DOTweenPresenceDetector.cs
+++ b/SkillsForUnity/Editor/Skills/DOTweenPresenceDetector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEditor.Compilation;
 using UnityEngine;
 
@@ -57,7 +58,7 @@ namespace UnitySkills
                 if (IsObsoleteBuildTargetGroup(btg)) continue;
 
                 string currentDefs;
-                try { currentDefs = PlayerSettings.GetScriptingDefineSymbolsForGroup(btg) ?? string.Empty; }
+                try { currentDefs = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(btg)) ?? string.Empty; }
                 catch { continue; }
 
                 var defList = currentDefs
@@ -93,7 +94,7 @@ namespace UnitySkills
         {
             try
             {
-                PlayerSettings.SetScriptingDefineSymbolsForGroup(btg, string.Join(";", defs));
+                PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(btg), string.Join(";", defs));
             }
             catch (Exception ex)
             {

--- a/SkillsForUnity/Editor/Skills/DOTweenSkills.cs
+++ b/SkillsForUnity/Editor/Skills/DOTweenSkills.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Newtonsoft.Json;
 using UnityEditor;
 using UnityEngine;
+using UnitySkills.Internal;
 
 namespace UnitySkills
 {
@@ -591,12 +592,7 @@ namespace UnitySkills
             }
             else
             {
-#if UNITY_6000_0_OR_NEWER
-                comps = UnityEngine.Object.FindObjectsByType(type, FindObjectsInactive.Include, FindObjectsSortMode.None)
-                    .OfType<Component>().ToArray();
-#else
-                comps = UnityEngine.Object.FindObjectsOfType(type).OfType<Component>().ToArray();
-#endif
+                comps = FindHelper.FindAll(type, includeInactive: true).OfType<Component>().ToArray();
             }
 
             var list = new List<object>();
@@ -609,7 +605,8 @@ namespace UnitySkills
                     list.Add(new
                     {
                         gameObject = g.Key.name,
-                        instanceId = g.Key.GetInstanceID(),
+                        entityId = UnityObjectIdUtility.GetEntityId(g.Key),
+                        instanceId = UnityObjectIdUtility.GetObjectId(g.Key),
                         animationIndex = idx++,
                         animationType = DOTweenReflectionHelper.GetFieldByCandidates(c, DOTweenReflectionHelper.AnimationTypeFieldCandidates)?.ToString(),
                         duration = DOTweenReflectionHelper.GetFieldByCandidates(c, DOTweenReflectionHelper.DurationFieldCandidates),

--- a/SkillsForUnity/Editor/Skills/DebugSkills.cs
+++ b/SkillsForUnity/Editor/Skills/DebugSkills.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEditor.Compilation;
 using System.Linq;
 using System.Collections.Generic;
@@ -284,7 +285,7 @@ namespace UnitySkills
         public static object DebugGetDefines()
         {
             var group = EditorUserBuildSettings.selectedBuildTargetGroup;
-            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(group);
+            var defines = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(group));
             return new { success = true, buildTargetGroup = group.ToString(), defines };
         }
 
@@ -296,7 +297,7 @@ namespace UnitySkills
         public static object DebugSetDefines(string defines)
         {
             var group = EditorUserBuildSettings.selectedBuildTargetGroup;
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(group, defines);
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(group), defines);
             return new
             {
                 success = true,

--- a/SkillsForUnity/Editor/Skills/DecalSkills.cs
+++ b/SkillsForUnity/Editor/Skills/DecalSkills.cs
@@ -333,7 +333,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = projector.gameObject.name,
-                instanceId = projector.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(projector.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(projector.gameObject),
                 path = GameObjectFinder.GetPath(projector.gameObject),
                 material = projector.material != null ? new
                 {

--- a/SkillsForUnity/Editor/Skills/EditorSkills.cs
+++ b/SkillsForUnity/Editor/Skills/EditorSkills.cs
@@ -78,7 +78,8 @@ namespace UnitySkills
             var selected = Selection.gameObjects.Select(go => new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID()
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go)
             }).ToArray();
 
             return new { count = selected.Length, objects = selected };
@@ -183,7 +184,8 @@ namespace UnitySkills
                 var info = new System.Collections.Generic.Dictionary<string, object>
                 {
                     ["name"] = go.name,
-                    ["instanceId"] = go.GetInstanceID(),
+                    ["entityId"] = UnityObjectIdUtility.GetEntityId(go),
+                    ["instanceId"] = UnityObjectIdUtility.GetObjectId(go),
                     ["path"] = GameObjectFinder.GetPath(go),
                     ["tag"] = go.tag,
                     ["layer"] = LayerMask.LayerToName(go.layer),
@@ -203,7 +205,7 @@ namespace UnitySkills
                     var children = new System.Collections.Generic.List<object>();
                     foreach (Transform child in go.transform)
                     {
-                        children.Add(new { name = child.name, instanceId = child.gameObject.GetInstanceID() });
+                        children.Add(new { name = child.name, entityId = UnityObjectIdUtility.GetEntityId(child.gameObject), instanceId = UnityObjectIdUtility.GetObjectId(child.gameObject) });
                     }
                     info["children"] = children;
                 }

--- a/SkillsForUnity/Editor/Skills/EventSkills.cs
+++ b/SkillsForUnity/Editor/Skills/EventSkills.cs
@@ -26,7 +26,7 @@ namespace UnitySkills
             if (findErr != null) return findErr;
 
             // Find component
-            var component = go.GetComponent(componentName);
+            var component = FindComponentOnGameObject(go, componentName);
             if (component == null)
                 return new { error = $"Component not found: {componentName} on {go.name}" };
 
@@ -91,7 +91,7 @@ namespace UnitySkills
             var (go, goErr) = GameObjectFinder.FindOrError(name: name, instanceId: instanceId, path: path);
             if (goErr != null) return goErr;
 
-            var component = go.GetComponent(componentName);
+            var component = FindComponentOnGameObject(go, componentName);
             if (component == null) return new { error = $"Source Component not found: {componentName}" };
 
             var (targetGo, tgtErr) = GameObjectFinder.FindOrError(name: targetObjectName);
@@ -107,7 +107,7 @@ namespace UnitySkills
             }
             else
             {
-                var targetComponent = targetGo.GetComponent(targetComponentName);
+                var targetComponent = FindComponentOnGameObject(targetGo, targetComponentName);
                 if (targetComponent == null) return new { error = $"Target Component not found: {targetComponentName}" };
                 targetObj = targetComponent;
                 targetType = targetComponent.GetType();
@@ -223,7 +223,7 @@ namespace UnitySkills
             var (go, findErr) = GameObjectFinder.FindOrError(name: name, instanceId: instanceId, path: path);
             if (findErr != null) return findErr;
 
-            var component = go.GetComponent(componentName);
+            var component = FindComponentOnGameObject(go, componentName);
             if (component == null) return new { error = $"Component not found: {componentName}" };
 
             var type = component.GetType();
@@ -255,7 +255,7 @@ namespace UnitySkills
              var (go, goErr) = GameObjectFinder.FindOrError(name: name, instanceId: instanceId, path: path);
             if (goErr != null) return goErr;
 
-            var component = go.GetComponent(componentName);
+            var component = FindComponentOnGameObject(go, componentName);
             if (component == null) return new { error = $"Component not found: {componentName}" };
 
             var type = component.GetType();
@@ -291,7 +291,7 @@ namespace UnitySkills
         {
             var (go, findErr) = GameObjectFinder.FindOrError(name: name, instanceId: instanceId, path: path);
             if (findErr != null) return (null, null, findErr);
-            var component = go.GetComponent(componentName);
+            var component = FindComponentOnGameObject(go, componentName);
             if (component == null) return (null, null, new { error = $"Component not found: {componentName}" });
             var type = component.GetType();
             var field = type.GetField(eventName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
@@ -332,10 +332,7 @@ namespace UnitySkills
                 return true;
             }
 
-            var componentType = ComponentSkills.FindComponentType(targetComponentName);
-            var targetComponent = componentType != null
-                ? targetGo.GetComponent(componentType)
-                : targetGo.GetComponent(targetComponentName);
+            var targetComponent = FindComponentOnGameObject(targetGo, targetComponentName);
             if (targetComponent == null)
             {
                 error = $"Target Component not found: {targetComponentName}";
@@ -345,6 +342,30 @@ namespace UnitySkills
             targetObj = targetComponent;
             targetType = targetComponent.GetType();
             return true;
+        }
+
+        private static Component FindComponentOnGameObject(GameObject go, string componentName)
+        {
+            if (go == null || string.IsNullOrWhiteSpace(componentName))
+                return null;
+
+            var componentType = ComponentSkills.FindComponentType(componentName);
+            if (componentType != null)
+            {
+                var component = go.GetComponent(componentType);
+                if (component != null)
+                    return component;
+            }
+
+            var byName = go.GetComponent(componentName);
+            if (byName != null)
+                return byName;
+
+            return go.GetComponents<Component>()
+                .FirstOrDefault(component =>
+                    component != null &&
+                    (string.Equals(component.GetType().Name, componentName, System.StringComparison.OrdinalIgnoreCase) ||
+                     string.Equals(component.GetType().FullName, componentName, System.StringComparison.OrdinalIgnoreCase)));
         }
 
         private static MethodInfo FindTargetMethod(System.Type targetType, string methodName, System.Type[] parameterTypes)
@@ -568,7 +589,7 @@ namespace UnitySkills
         {
             var (go, findErr) = GameObjectFinder.FindOrError(name: name, instanceId: instanceId, path: path);
             if (findErr != null) return findErr;
-            var component = go.GetComponent(componentName);
+            var component = FindComponentOnGameObject(go, componentName);
             if (component == null) return new { error = $"Component not found: {componentName}" };
             var type = component.GetType();
             var events = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)

--- a/SkillsForUnity/Editor/Skills/GameObjectFinder.cs
+++ b/SkillsForUnity/Editor/Skills/GameObjectFinder.cs
@@ -16,14 +16,38 @@ namespace UnitySkills.Internal
     {
         internal static T[] FindAll<T>(bool includeInactive = false) where T : Object
         {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
+            return includeInactive
+                ? Object.FindObjectsByType<T>(FindObjectsInactive.Include)
+                : Object.FindObjectsByType<T>(FindObjectsInactive.Exclude);
+#elif UNITY_6000_0_OR_NEWER || UNITY_2022_2_OR_NEWER
             return includeInactive
                 ? Object.FindObjectsByType<T>(FindObjectsInactive.Include, FindObjectsSortMode.None)
-                : Object.FindObjectsByType<T>(FindObjectsSortMode.None);
+                : Object.FindObjectsByType<T>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
 #else
             return includeInactive
                 ? Resources.FindObjectsOfTypeAll<T>()
                 : Object.FindObjectsOfType<T>();
+#endif
+        }
+
+        internal static Object[] FindAll(System.Type type, bool includeInactive = false)
+        {
+            if (type == null)
+                return System.Array.Empty<Object>();
+
+#if UNITY_6000_4_OR_NEWER
+            return includeInactive
+                ? Object.FindObjectsByType(type, FindObjectsInactive.Include)
+                : Object.FindObjectsByType(type, FindObjectsInactive.Exclude);
+#elif UNITY_6000_0_OR_NEWER || UNITY_2022_2_OR_NEWER
+            return includeInactive
+                ? Object.FindObjectsByType(type, FindObjectsInactive.Include, FindObjectsSortMode.None)
+                : Object.FindObjectsByType(type, FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+#else
+            return includeInactive
+                ? Resources.FindObjectsOfTypeAll(type)
+                : Object.FindObjectsOfType(type);
 #endif
         }
     }
@@ -135,7 +159,7 @@ namespace UnitySkills
 
     /// <summary>
     /// Unified utility for finding GameObjects by multiple methods.
-    /// Supports: name, instance ID, hierarchy path, tag, component type.
+    /// Supports: name, entityId, legacy instance ID, hierarchy path, tag, component type.
     /// Enhanced with intelligent fallback search strategies.
     /// </summary>
     public static class GameObjectFinder
@@ -143,8 +167,10 @@ namespace UnitySkills
         private sealed class SceneObjectCache
         {
             public readonly List<GameObject> Objects = new List<GameObject>();
-            public readonly Dictionary<int, string> PathsByInstanceId = new Dictionary<int, string>();
-            public readonly Dictionary<int, int> DepthsByInstanceId = new Dictionary<int, int>();
+            public readonly Dictionary<string, string> PathsByEntityId =
+                new Dictionary<string, string>(System.StringComparer.Ordinal);
+            public readonly Dictionary<string, int> DepthsByEntityId =
+                new Dictionary<string, int>(System.StringComparer.Ordinal);
             public readonly Dictionary<string, GameObject> PathLookup =
                 new Dictionary<string, GameObject>(System.StringComparer.OrdinalIgnoreCase);
         }
@@ -180,11 +206,14 @@ namespace UnitySkills
             {
                 var (transform, path, sceneName, depth) = stack.Pop();
                 var gameObject = transform.gameObject;
-                var instanceId = gameObject.GetInstanceID();
+                var entityId = UnityObjectIdUtility.GetEntityId(gameObject);
 
                 cache.Objects.Add(gameObject);
-                cache.PathsByInstanceId[instanceId] = path;
-                cache.DepthsByInstanceId[instanceId] = depth;
+                if (!string.IsNullOrEmpty(entityId))
+                {
+                    cache.PathsByEntityId[entityId] = path;
+                    cache.DepthsByEntityId[entityId] = depth;
+                }
                 AddPathLookup(cache.PathLookup, path, gameObject);
 
                 if (!string.IsNullOrEmpty(sceneName))
@@ -224,9 +253,10 @@ namespace UnitySkills
             if (go == null)
                 return 0;
 
-            var instanceId = go.GetInstanceID();
+            var entityId = UnityObjectIdUtility.GetEntityId(go);
             if (_cachedSceneData != null && _cacheValid &&
-                _cachedSceneData.DepthsByInstanceId.TryGetValue(instanceId, out var depth))
+                !string.IsNullOrEmpty(entityId) &&
+                _cachedSceneData.DepthsByEntityId.TryGetValue(entityId, out var depth))
                 return depth;
 
             depth = 0;
@@ -237,8 +267,8 @@ namespace UnitySkills
                 parent = parent.parent;
             }
 
-            if (_cachedSceneData != null && _cacheValid)
-                _cachedSceneData.DepthsByInstanceId[instanceId] = depth;
+            if (_cachedSceneData != null && _cacheValid && !string.IsNullOrEmpty(entityId))
+                _cachedSceneData.DepthsByEntityId[entityId] = depth;
 
             return depth;
         }
@@ -279,25 +309,38 @@ namespace UnitySkills
 
         /// <summary>
         /// Find a GameObject using flexible parameters with intelligent fallback.
-        /// Priority: instanceId > path > name (exact) > name (contains) > tag > component
+        /// Priority: entityId > instanceId > path > name (exact) > name (contains) > tag > component
         /// </summary>
         /// <param name="name">Simple name to search (uses GameObject.Find, then fallback to contains)</param>
-        /// <param name="instanceId">Unity instance ID (most precise)</param>
+        /// <param name="instanceId">Legacy Unity instance ID fallback</param>
         /// <param name="path">Hierarchy path like "Parent/Child/Target"</param>
         /// <param name="tag">Tag to search by (e.g., "MainCamera", "Player")</param>
         /// <param name="componentType">Find first object with this component (e.g., "Camera")</param>
+        /// <param name="entityId">Unity EntityId serialized as a decimal ulong string</param>
         /// <returns>Found GameObject or null</returns>
-        public static GameObject Find(string name = null, int instanceId = 0, string path = null, string tag = null, string componentType = null)
+        public static GameObject Find(string name = null, int instanceId = 0, string path = null, string tag = null, string componentType = null, string entityId = null)
         {
-            // Priority 1: Instance ID (most precise, works regardless of selection/focus)
-            if (instanceId != 0)
+            // Priority 1: EntityId (most precise, Unity 6000.5-safe).
+            if (!string.IsNullOrWhiteSpace(entityId))
             {
-                var obj = EditorUtility.InstanceIDToObject(instanceId);
+                var obj = UnityObjectIdUtility.EntityIdToObject(entityId);
                 if (obj is GameObject go)
                     return go;
+                if (obj is Component component)
+                    return component.gameObject;
             }
 
-            // Priority 2: Hierarchy path (works for nested objects)
+            // Priority 2: Legacy instance ID fallback.
+            if (instanceId != 0)
+            {
+                var obj = UnityObjectIdUtility.ObjectIdToObject(instanceId);
+                if (obj is GameObject go)
+                    return go;
+                if (obj is Component component)
+                    return component.gameObject;
+            }
+
+            // Priority 3: Hierarchy path (works for nested objects)
             if (!string.IsNullOrEmpty(path))
             {
                 var go = FindByPath(path);
@@ -305,7 +348,7 @@ namespace UnitySkills
                     return go;
             }
 
-            // Priority 3: Simple name search (exact match first)
+            // Priority 4: Simple name search (exact match first)
             if (!string.IsNullOrEmpty(name))
             {
                 var go = FindByNameCaseInsensitive(name);
@@ -318,7 +361,7 @@ namespace UnitySkills
                     return go;
             }
 
-            // Priority 4: Tag search
+            // Priority 5: Tag search
             if (!string.IsNullOrEmpty(tag))
             {
                 var go = GetAllSceneObjects().FirstOrDefault(candidate =>
@@ -330,7 +373,7 @@ namespace UnitySkills
                     return go;
             }
 
-            // Priority 5: Component type search
+            // Priority 6: Component type search
             if (!string.IsNullOrEmpty(componentType))
             {
                 var go = FindByComponent(componentType);
@@ -509,25 +552,28 @@ namespace UnitySkills
             if (go == null)
                 return null;
 
-            var instanceId = go.GetInstanceID();
+            var entityId = UnityObjectIdUtility.GetEntityId(go);
             var cache = GetOrBuildSceneCache();
-            if (cache.PathsByInstanceId.TryGetValue(instanceId, out var cachedPath))
+            if (!string.IsNullOrEmpty(entityId) &&
+                cache.PathsByEntityId.TryGetValue(entityId, out var cachedPath))
                 return cachedPath;
 
             var path = GetPath(go);
-            cache.PathsByInstanceId[instanceId] = path;
+            if (!string.IsNullOrEmpty(entityId))
+                cache.PathsByEntityId[entityId] = path;
             return path;
         }
 
         /// <summary>
         /// Find or report error with helpful suggestions
         /// </summary>
-        public static (GameObject go, object error) FindOrError(string name = null, int instanceId = 0, string path = null, string tag = null, string componentType = null)
+        public static (GameObject go, object error) FindOrError(string name = null, int instanceId = 0, string path = null, string tag = null, string componentType = null, string entityId = null)
         {
-            var go = Find(name, instanceId, path, tag, componentType);
+            var go = Find(name, instanceId, path, tag, componentType, entityId);
             if (go == null)
             {
-                var identifier = instanceId != 0 ? $"instanceId {instanceId}" : 
+                var identifier = !string.IsNullOrEmpty(entityId) ? $"entityId {entityId}" :
+                    instanceId != 0 ? $"instanceId {instanceId}" :
                     !string.IsNullOrEmpty(path) ? $"path '{path}'" :
                     !string.IsNullOrEmpty(tag) ? $"tag '{tag}'" :
                     !string.IsNullOrEmpty(componentType) ? $"component '{componentType}'" :
@@ -547,9 +593,9 @@ namespace UnitySkills
         /// <summary>
         /// Find a GameObject and get a required component, or return an error.
         /// </summary>
-        public static (T component, object error) FindComponentOrError<T>(string name = null, int instanceId = 0, string path = null) where T : Component
+        public static (T component, object error) FindComponentOrError<T>(string name = null, int instanceId = 0, string path = null, string entityId = null) where T : Component
         {
-            var (go, err) = FindOrError(name, instanceId, path);
+            var (go, err) = FindOrError(name, instanceId, path, entityId: entityId);
             if (err != null) return (null, err);
             var comp = go.GetComponent<T>();
             if (comp == null) return (null, new { error = $"No {typeof(T).Name} component on {go.name}" });

--- a/SkillsForUnity/Editor/Skills/GameObjectSkills.cs
+++ b/SkillsForUnity/Editor/Skills/GameObjectSkills.cs
@@ -7,7 +7,7 @@ namespace UnitySkills
 {
     /// <summary>
     /// GameObject management skills - create, modify, delete, find.
-    /// Now supports finding by name, instanceId, or path.
+    /// Now supports finding by name, entityId, legacy instanceId, or path.
     /// </summary>
     public static class GameObjectSkills
     {
@@ -42,9 +42,9 @@ namespace UnitySkills
                 }
 
                 // Set parent if specified
-                if (!string.IsNullOrEmpty(item.parentName) || item.parentInstanceId != 0 || !string.IsNullOrEmpty(item.parentPath))
+                if (!string.IsNullOrEmpty(item.parentEntityId) || !string.IsNullOrEmpty(item.parentName) || item.parentInstanceId != 0 || !string.IsNullOrEmpty(item.parentPath))
                 {
-                    var (parentGo, parentErr) = GameObjectFinder.FindOrError(item.parentName, item.parentInstanceId, item.parentPath);
+                    var (parentGo, parentErr) = GameObjectFinder.FindOrError(item.parentName, item.parentInstanceId, item.parentPath, entityId: item.parentEntityId);
                     if (parentErr != null) throw new System.Exception($"Parent not found for '{item.name}'");
                     go.transform.SetParent(parentGo.transform, false);
                 }
@@ -62,7 +62,8 @@ namespace UnitySkills
                 {
                     success = true,
                     name = go.name,
-                    instanceId = go.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(go),
+                    instanceId = UnityObjectIdUtility.GetObjectId(go),
                     path = GameObjectFinder.GetPath(go),
                     position = new { x = item.x, y = item.y, z = item.z }
                 };
@@ -83,6 +84,7 @@ namespace UnitySkills
             public float scaleY { get; set; } = 1;
             public float scaleZ { get; set; } = 1;
             public string parentName { get; set; }
+            public string parentEntityId { get; set; }
             public int parentInstanceId { get; set; }
             public string parentPath { get; set; }
         }
@@ -94,13 +96,13 @@ namespace UnitySkills
             TracksWorkflow = true,
             MutatesScene = true, RiskLevel = "medium")]
         public static object GameObjectCreate(string name, string primitiveType = null, float x = 0, float y = 0, float z = 0,
-            string parentName = null, int parentInstanceId = 0, string parentPath = null)
+            string parentName = null, int parentInstanceId = 0, string parentPath = null, string parentEntityId = null)
         {
             // Resolve parent first so we fail fast before creating the object
             GameObject parentGo = null;
-            if (!string.IsNullOrEmpty(parentName) || parentInstanceId != 0 || !string.IsNullOrEmpty(parentPath))
+            if (!string.IsNullOrEmpty(parentEntityId) || !string.IsNullOrEmpty(parentName) || parentInstanceId != 0 || !string.IsNullOrEmpty(parentPath))
             {
-                var (found, parentErr) = GameObjectFinder.FindOrError(parentName, parentInstanceId, parentPath);
+                var (found, parentErr) = GameObjectFinder.FindOrError(parentName, parentInstanceId, parentPath, entityId: parentEntityId);
                 if (parentErr != null) return parentErr;
                 parentGo = found;
             }
@@ -136,7 +138,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetPath(go),
                 parent = parentGo != null ? parentGo.name : "(root)",
                 position = new { x, y, z }
@@ -149,11 +152,11 @@ namespace UnitySkills
             Outputs = new[] { "oldName", "newName", "instanceId", "path" },
             RequiresInput = new[] { "gameObject" },
             TracksWorkflow = true)]
-        public static object GameObjectRename(string name = null, int instanceId = 0, string path = null, string newName = null)
+        public static object GameObjectRename(string name = null, int instanceId = 0, string path = null, string newName = null, string entityId = null)
         {
             if (Validate.Required(newName, "newName") is object err) return err;
 
-            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path);
+            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path, entityId: entityId);
             if (error != null) return error;
 
             var oldName = go.name;
@@ -165,7 +168,8 @@ namespace UnitySkills
                 success = true, 
                 oldName, 
                 newName = go.name, 
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetPath(go)
             };
         }
@@ -183,7 +187,7 @@ namespace UnitySkills
                 if (string.IsNullOrEmpty(item.newName))
                     throw new System.Exception("newName is required");
 
-                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                 if (error != null) throw new System.Exception("Object not found");
 
                 var oldName = go.name;
@@ -191,13 +195,14 @@ namespace UnitySkills
                 Undo.RecordObject(go, "Batch Rename " + go.name);
                 go.name = item.newName;
 
-                return new { success = true, oldName, newName = go.name, instanceId = go.GetInstanceID() };
-            }, item => item.name ?? item.path ?? item.instanceId.ToString());
+                return new { success = true, oldName, newName = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go) };
+            }, item => item.name ?? item.path ?? item.entityId ?? item.instanceId.ToString());
         }
 
         private class BatchRenameItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
             public string newName { get; set; }
@@ -210,9 +215,9 @@ namespace UnitySkills
             RequiresInput = new[] { "gameObject" },
             TracksWorkflow = true,
             MutatesScene = true, RiskLevel = "medium")]
-        public static object GameObjectDelete(string name = null, int instanceId = 0, string path = null)
+        public static object GameObjectDelete(string name = null, int instanceId = 0, string path = null, string entityId = null)
         {
-            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path);
+            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path, entityId: entityId);
             if (error != null) return error;
 
             var deletedName = go.name;
@@ -236,7 +241,7 @@ namespace UnitySkills
                 var normalizedItems = NormalizeDeleteBatchItems(items);
                 return BatchExecutor.Execute<BatchDeleteItem>(normalizedItems, item =>
                 {
-                    var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                    var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                     if (error != null)
                         throw new System.Exception("Object not found");
 
@@ -244,7 +249,7 @@ namespace UnitySkills
                     WorkflowManager.SnapshotObject(go);
                     Undo.DestroyObjectImmediate(go);
                     return new { target = deletedName, success = true };
-                }, item => item.name ?? item.path ?? item.instanceId.ToString());
+                }, item => item.name ?? item.path ?? item.entityId ?? item.instanceId.ToString());
             }
             catch (System.Exception ex)
             {
@@ -269,6 +274,7 @@ namespace UnitySkills
         private class BatchDeleteItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
         }
@@ -327,7 +333,8 @@ namespace UnitySkills
             var list = results.Take(limit).Select(go => new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetCachedPath(go),
                 tag = go.tag,
                 layer = LayerMask.LayerToName(go.layer),
@@ -357,9 +364,10 @@ namespace UnitySkills
             float? anchorMaxX = null, float? anchorMaxY = null,
             float? pivotX = null, float? pivotY = null,
             float? sizeDeltaX = null, float? sizeDeltaY = null,
-            float? width = null, float? height = null)
+            float? width = null, float? height = null,
+            string entityId = null)
         {
-            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path);
+            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path, entityId: entityId);
             if (error != null) return error;
 
             WorkflowManager.SnapshotObject(go.transform);
@@ -404,7 +412,8 @@ namespace UnitySkills
                 {
                     success = true,
                     name = go.name,
-                    instanceId = go.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(go),
+                    instanceId = UnityObjectIdUtility.GetObjectId(go),
                     isUI = true,
                     anchoredPosition = new { x = rt.anchoredPosition.x, y = rt.anchoredPosition.y },
                     anchorMin = new { x = rt.anchorMin.x, y = rt.anchorMin.y },
@@ -420,7 +429,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 isUI = false,
                 position = new { x = go.transform.position.x, y = go.transform.position.y, z = go.transform.position.z },
                 localPosition = new { x = go.transform.localPosition.x, y = go.transform.localPosition.y, z = go.transform.localPosition.z },
@@ -439,7 +449,7 @@ namespace UnitySkills
         {
             return BatchExecutor.Execute<BatchTransformItem>(items, item =>
             {
-                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                 if (error != null) throw new System.Exception("Object not found");
 
                 WorkflowManager.SnapshotObject(go.transform);
@@ -479,14 +489,16 @@ namespace UnitySkills
                 {
                     success = true,
                     name = go.name,
+                    entityId = UnityObjectIdUtility.GetEntityId(go),
                     pos = new { x = go.transform.position.x, y = go.transform.position.y, z = go.transform.position.z }
                 };
-            }, item => item.name ?? item.path);
+            }, item => item.name ?? item.path ?? item.entityId);
         }
 
         private class BatchTransformItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
 
@@ -541,9 +553,9 @@ namespace UnitySkills
             Outputs = new[] { "copyName", "copyInstanceId", "copyPath" },
             RequiresInput = new[] { "gameObject" },
             TracksWorkflow = true)]
-        public static object GameObjectDuplicate(string name = null, int instanceId = 0, string path = null)
+        public static object GameObjectDuplicate(string name = null, int instanceId = 0, string path = null, string entityId = null)
         {
-            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path);
+            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path, entityId: entityId);
             if (error != null) return error;
 
             var copy = Object.Instantiate(go, go.transform.parent);
@@ -555,7 +567,8 @@ namespace UnitySkills
                 success = true,
                 originalName = go.name,
                 copyName = copy.name,
-                copyInstanceId = copy.GetInstanceID(),
+                copyEntityId = UnityObjectIdUtility.GetEntityId(copy),
+                copyInstanceId = UnityObjectIdUtility.GetObjectId(copy),
                 copyPath = GameObjectFinder.GetPath(copy)
             };
         }
@@ -569,7 +582,7 @@ namespace UnitySkills
         {
             return BatchExecutor.Execute<BatchDuplicateItem>(items, item =>
             {
-                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                 if (error != null) throw new System.Exception("Object not found");
 
                 var copy = Object.Instantiate(go, go.transform.parent);
@@ -582,15 +595,17 @@ namespace UnitySkills
                     success = true,
                     originalName = go.name,
                     copyName = copy.name,
-                    copyInstanceId = copy.GetInstanceID(),
+                    copyEntityId = UnityObjectIdUtility.GetEntityId(copy),
+                    copyInstanceId = UnityObjectIdUtility.GetObjectId(copy),
                     copyPath = GameObjectFinder.GetPath(copy)
                 };
-            }, item => item.name ?? item.path ?? item.instanceId.ToString());
+            }, item => item.name ?? item.path ?? item.entityId ?? item.instanceId.ToString());
         }
 
         private class BatchDuplicateItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
         }
@@ -602,15 +617,15 @@ namespace UnitySkills
             RequiresInput = new[] { "gameObject" },
             TracksWorkflow = true)]
         public static object GameObjectSetParent(string childName = null, int childInstanceId = 0, string childPath = null, 
-            string parentName = null, int parentInstanceId = 0, string parentPath = null)
+            string parentName = null, int parentInstanceId = 0, string parentPath = null, string childEntityId = null, string parentEntityId = null)
         {
-            var (child, childError) = GameObjectFinder.FindOrError(childName, childInstanceId, childPath);
+            var (child, childError) = GameObjectFinder.FindOrError(childName, childInstanceId, childPath, entityId: childEntityId);
             if (childError != null) return childError;
 
             Transform parent = null;
-            if (!string.IsNullOrEmpty(parentName) || parentInstanceId != 0 || !string.IsNullOrEmpty(parentPath))
+            if (!string.IsNullOrEmpty(parentEntityId) || !string.IsNullOrEmpty(parentName) || parentInstanceId != 0 || !string.IsNullOrEmpty(parentPath))
             {
-                var (parentGo, parentError) = GameObjectFinder.FindOrError(parentName, parentInstanceId, parentPath);
+                var (parentGo, parentError) = GameObjectFinder.FindOrError(parentName, parentInstanceId, parentPath, entityId: parentEntityId);
                 if (parentError != null) return parentError;
                 parent = parentGo.transform;
             }
@@ -620,7 +635,9 @@ namespace UnitySkills
             return new { 
                 success = true, 
                 child = child.name, 
+                childEntityId = UnityObjectIdUtility.GetEntityId(child),
                 parent = parent?.name ?? "(root)",
+                parentEntityId = parent != null ? UnityObjectIdUtility.GetEntityId(parent.gameObject) : null,
                 newPath = GameObjectFinder.GetPath(child)
             };
         }
@@ -632,9 +649,9 @@ namespace UnitySkills
             RequiresInput = new[] { "gameObject" },
             ReadOnly = true,
             Mode = SkillMode.SemiAuto)]
-        public static object GameObjectGetInfo(string name = null, int instanceId = 0, string path = null)
+        public static object GameObjectGetInfo(string name = null, int instanceId = 0, string path = null, string entityId = null)
         {
-            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path);
+            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path, entityId: entityId);
             if (error != null) return error;
 
             var componentBuffer = new List<Component>(8);
@@ -652,7 +669,8 @@ namespace UnitySkills
                 children.Add(new
                 {
                     name = child.name,
-                    instanceId = child.gameObject.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(child.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(child.gameObject),
                     path = GameObjectFinder.GetCachedPath(child.gameObject)
                 });
             }
@@ -660,7 +678,8 @@ namespace UnitySkills
             return new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetCachedPath(go),
                 tag = go.tag,
                 layer = LayerMask.LayerToName(go.layer),
@@ -682,16 +701,16 @@ namespace UnitySkills
             Outputs = new[] { "name", "active" },
             RequiresInput = new[] { "gameObject" },
             TracksWorkflow = true)]
-        public static object GameObjectSetActive(string name = null, int instanceId = 0, string path = null, bool active = true)
+        public static object GameObjectSetActive(string name = null, int instanceId = 0, string path = null, bool active = true, string entityId = null)
         {
-            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path);
+            var (go, error) = GameObjectFinder.FindOrError(name, instanceId, path, entityId: entityId);
             if (error != null) return error;
 
             WorkflowManager.SnapshotObject(go);
             Undo.RecordObject(go, "Set Active");
             go.SetActive(active);
 
-            return new { success = true, name = go.name, active };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), active };
         }
 
         [UnitySkill("gameobject_set_active_batch", "Enable or disable multiple GameObjects. items: JSON array of {name, active}",
@@ -703,19 +722,20 @@ namespace UnitySkills
         {
             return BatchExecutor.Execute<BatchSetActiveItem>(items, item =>
             {
-                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                 if (error != null) throw new System.Exception("Object not found");
 
                 WorkflowManager.SnapshotObject(go);
                 Undo.RecordObject(go, "Batch Set Active");
                 go.SetActive(item.active);
-                return new { target = go.name, success = true, active = item.active };
-            }, item => item.name ?? item.path);
+                return new { target = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), success = true, active = item.active };
+            }, item => item.name ?? item.path ?? item.entityId);
         }
 
         public class BatchSetActiveItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
             public bool active { get; set; } = true;
@@ -730,7 +750,7 @@ namespace UnitySkills
         {
             return BatchExecutor.Execute<BatchSetLayerItem>(items, item =>
             {
-                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                 if (error != null) throw new System.Exception("Object not found");
 
                 int layerId = LayerMask.NameToLayer(item.layer);
@@ -750,13 +770,14 @@ namespace UnitySkills
                     }
                 }
 
-                return new { target = go.name, success = true, layer = item.layer };
-            }, item => item.name ?? item.path);
+                return new { target = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), success = true, layer = item.layer };
+            }, item => item.name ?? item.path ?? item.entityId);
         }
 
         private class BatchSetLayerItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
             public string layer { get; set; }
@@ -772,19 +793,20 @@ namespace UnitySkills
         {
             return BatchExecutor.Execute<BatchSetTagItem>(items, item =>
             {
-                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path);
+                var (go, error) = GameObjectFinder.FindOrError(item.name, item.instanceId, item.path, entityId: item.entityId);
                 if (error != null) throw new System.Exception("Object not found");
 
                 WorkflowManager.SnapshotObject(go);
                 Undo.RecordObject(go, "Batch Set Tag");
                 go.tag = item.tag;
-                return new { target = go.name, success = true, tag = item.tag };
-            }, item => item.name ?? item.path);
+                return new { target = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), success = true, tag = item.tag };
+            }, item => item.name ?? item.path ?? item.entityId);
         }
 
         private class BatchSetTagItem
         {
             public string name { get; set; }
+            public string entityId { get; set; }
             public int instanceId { get; set; }
             public string path { get; set; }
             public string tag { get; set; }
@@ -799,13 +821,13 @@ namespace UnitySkills
         {
             return BatchExecutor.Execute<BatchSetParentItem>(items, item =>
             {
-                var (child, childError) = GameObjectFinder.FindOrError(item.childName, item.childInstanceId, item.childPath);
+                var (child, childError) = GameObjectFinder.FindOrError(item.childName, item.childInstanceId, item.childPath, entityId: item.childEntityId);
                 if (childError != null) throw new System.Exception("Child object not found");
 
                 Transform parent = null;
-                if (!string.IsNullOrEmpty(item.parentName) || item.parentInstanceId != 0 || !string.IsNullOrEmpty(item.parentPath))
+                if (!string.IsNullOrEmpty(item.parentEntityId) || !string.IsNullOrEmpty(item.parentName) || item.parentInstanceId != 0 || !string.IsNullOrEmpty(item.parentPath))
                 {
-                    var (parentGo, parentError) = GameObjectFinder.FindOrError(item.parentName, item.parentInstanceId, item.parentPath);
+                    var (parentGo, parentError) = GameObjectFinder.FindOrError(item.parentName, item.parentInstanceId, item.parentPath, entityId: item.parentEntityId);
                     if (parentError != null)
                         throw new System.Exception($"Parent not found: {item.parentName ?? item.parentPath}");
                     parent = parentGo.transform;
@@ -816,18 +838,21 @@ namespace UnitySkills
                 return new
                 {
                     target = child.name,
+                    entityId = UnityObjectIdUtility.GetEntityId(child),
                     success = true,
                     parent = parent?.name ?? "(root)"
                 };
-            }, item => item.childName ?? item.childPath);
+            }, item => item.childName ?? item.childPath ?? item.childEntityId);
         }
 
         private class BatchSetParentItem
         {
             public string childName { get; set; }
+            public string childEntityId { get; set; }
             public int childInstanceId { get; set; }
             public string childPath { get; set; }
             public string parentName { get; set; }
+            public string parentEntityId { get; set; }
             public int parentInstanceId { get; set; }
             public string parentPath { get; set; }
         }

--- a/SkillsForUnity/Editor/Skills/LightSkills.cs
+++ b/SkillsForUnity/Editor/Skills/LightSkills.cs
@@ -72,7 +72,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 lightType = light.type.ToString(),
                 position = new { x, y, z },
                 color = new { r, g, b },
@@ -175,7 +176,8 @@ namespace UnitySkills
             return new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetPath(go),
                 lightType = light.type.ToString(),
                 color = new { r = light.color.r, g = light.color.g, b = light.color.b },
@@ -208,7 +210,8 @@ namespace UnitySkills
             var results = lights.Take(limit).Select(l => new
             {
                 name = l.gameObject.name,
-                instanceId = l.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(l.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(l.gameObject),
                 path = GameObjectFinder.GetPath(l.gameObject),
                 lightType = l.type.ToString(),
                 intensity = l.intensity,
@@ -379,7 +382,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Reflection Probe");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), resolution, size = new { x = sizeX, y = sizeY, z = sizeZ } };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), resolution, size = new { x = sizeX, y = sizeY, z = sizeZ } };
         }
 
         [UnitySkill("light_get_lightmap_settings", "Get Lightmap baking settings",

--- a/SkillsForUnity/Editor/Skills/MaterialSkills.cs
+++ b/SkillsForUnity/Editor/Skills/MaterialSkills.cs
@@ -169,7 +169,8 @@ namespace UnitySkills
                     name,
                     shader = shaderName,
                     path = (string)null,
-                    instanceId = material.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(material),
+                    instanceId = UnityObjectIdUtility.GetObjectId(material),
                     renderPipeline = pipelineType2.ToString(),
                     colorProperty = ProjectSkills.GetColorPropertyName(),
                     textureProperty = ProjectSkills.GetMainTexturePropertyName(),
@@ -183,6 +184,7 @@ namespace UnitySkills
                 name,
                 shader = shaderName,
                 path = savePath,
+                entityId = UnityObjectIdUtility.GetEntityId(material),
                 renderPipeline = pipelineType.ToString(),
                 colorProperty = ProjectSkills.GetColorPropertyName(),
                 textureProperty = ProjectSkills.GetMainTexturePropertyName()

--- a/SkillsForUnity/Editor/Skills/NetcodeSkills.cs
+++ b/SkillsForUnity/Editor/Skills/NetcodeSkills.cs
@@ -138,7 +138,7 @@ namespace UnitySkills
 #else
             var existing = FindHelper.FindAll<NetworkManager>(includeInactive: true);
             if (existing.Length > 0)
-                return new { error = $"NetworkManager already exists: '{existing[0].gameObject.name}' (instanceId={existing[0].gameObject.GetInstanceID()}). Only one is supported." };
+                return new { error = $"NetworkManager already exists: '{existing[0].gameObject.name}' (entityId={UnityObjectIdUtility.GetEntityId(existing[0].gameObject)}, instanceId={UnityObjectIdUtility.GetObjectId(existing[0].gameObject)}). Only one is supported." };
 
             var go = new GameObject(string.IsNullOrEmpty(name) ? "NetworkManager" : name);
             Undo.RegisterCreatedObjectUndo(go, "Create NetworkManager");
@@ -151,7 +151,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 transportType = nameof(UnityTransport)
             };
 #endif
@@ -276,7 +277,8 @@ namespace UnitySkills
             {
                 found = true,
                 name = nm.gameObject.name,
-                instanceId = nm.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(nm.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(nm.gameObject),
                 config = cfgSnap,
                 runtime
             };
@@ -501,7 +503,7 @@ namespace UnitySkills
 
             var existing = go.GetComponent<NetworkObject>();
             if (existing != null)
-                return new { error = $"GameObject '{go.name}' already has a NetworkObject (instanceId={existing.GetInstanceID()})." };
+                return new { error = $"GameObject '{go.name}' already has a NetworkObject (entityId={UnityObjectIdUtility.GetEntityId(existing)}, instanceId={UnityObjectIdUtility.GetObjectId(existing)})." };
 
             var no = Undo.AddComponent<NetworkObject>(go);
             if (alwaysReplicateAsRoot.HasValue) no.AlwaysReplicateAsRoot = alwaysReplicateAsRoot.Value;
@@ -518,7 +520,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 globalObjectIdHash = GetGlobalObjectIdHash(no)
             };
 #endif
@@ -608,7 +611,8 @@ namespace UnitySkills
             var list = all.Select(no => new
             {
                 name = no.gameObject.name,
-                instanceId = no.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(no.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(no.gameObject),
                 globalObjectIdHash = GetGlobalObjectIdHash(no),
                 isSpawned = Application.isPlaying && no.IsSpawned,
                 networkObjectId = Application.isPlaying && no.IsSpawned ? (ulong?)no.NetworkObjectId : null,
@@ -643,7 +647,8 @@ namespace UnitySkills
             {
                 found = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 globalObjectIdHash = GetGlobalObjectIdHash(no),
                 alwaysReplicateAsRoot = no.AlwaysReplicateAsRoot,
                 synchronizeTransform = no.SynchronizeTransform,
@@ -1217,7 +1222,8 @@ namespace UnitySkills
             {
                 type = nb.GetType().Name,
                 gameObject = nb.gameObject.name,
-                instanceId = nb.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(nb.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(nb.gameObject),
                 isSpawned = Application.isPlaying && nb.IsSpawned,
                 isOwner = Application.isPlaying && nb.IsOwner
             }).ToArray();

--- a/SkillsForUnity/Editor/Skills/PerceptionSkills.cs
+++ b/SkillsForUnity/Editor/Skills/PerceptionSkills.cs
@@ -1383,7 +1383,7 @@ namespace UnitySkills
                 foreach (var mat in renderer.sharedMaterials)
                 {
                     if (mat == null) continue;
-                    var key = mat.GetInstanceID().ToString();
+                    var key = UnityObjectIdUtility.GetEntityId(mat);
                     if (!materialMap.ContainsKey(key))
                     {
                         materialMap[key] = new MaterialInfo
@@ -1397,13 +1397,13 @@ namespace UnitySkills
                         if (includeProperties && mat.shader != null)
                         {
                             var props = new List<object>();
-                            int count = ShaderUtil.GetPropertyCount(mat.shader);
+                            int count = mat.shader.GetPropertyCount();
                             for (int i = 0; i < count; i++)
                             {
                                 props.Add(new
                                 {
-                                    name = ShaderUtil.GetPropertyName(mat.shader, i),
-                                    type = ShaderUtil.GetPropertyType(mat.shader, i).ToString()
+                                    name = mat.shader.GetPropertyName(i),
+                                    type = mat.shader.GetPropertyType(i).ToString()
                                 });
                             }
                             materialMap[key].properties = props;
@@ -2817,7 +2817,7 @@ namespace UnitySkills
             // 4. Duplicate materials
             var mats = renderers.SelectMany(r => r.sharedMaterials).Where(m => m != null).ToArray();
             var uniqueShaders = mats.Select(m => m.shader?.name).Distinct().Count();
-            var duplicateCount = mats.Length - mats.Select(m => m.GetInstanceID()).Distinct().Count();
+            var duplicateCount = mats.Length - mats.Select(UnityObjectIdUtility.GetEntityId).Distinct().Count();
             if (duplicateCount > 10)
                 hints.Add(new { priority = 3, category = "Materials", issue = $"{duplicateCount} duplicate material references",
                     suggestion = "Consolidate materials", fixSkill = "optimize_find_duplicate_materials" });
@@ -2866,20 +2866,20 @@ namespace UnitySkills
             try { previousSnapshot = JArray.Parse(snapshotJson); }
             catch (Exception ex) { return new { error = $"Invalid snapshotJson: {ex.Message}" }; }
 
-            var previousMap = new Dictionary<int, JObject>();
+            var previousMap = new Dictionary<string, JObject>(StringComparer.Ordinal);
             foreach (var item in previousSnapshot)
             {
-                var id = item["instanceId"]?.Value<int>() ?? 0;
-                if (id != 0)
+                var id = GetSnapshotIdentity(item as JObject);
+                if (!string.IsNullOrEmpty(id))
                     previousMap[id] = item as JObject;
             }
 
             var currentSnapshot = CaptureSceneSnapshot();
-            var currentMap = new Dictionary<int, Dictionary<string, object>>();
+            var currentMap = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
             foreach (var item in currentSnapshot)
             {
-                var id = GetPropertyValue<int>(item, "instanceId", 0);
-                if (id != 0)
+                var id = GetSnapshotIdentity(item);
+                if (!string.IsNullOrEmpty(id))
                     currentMap[id] = item as Dictionary<string, object> ?? new Dictionary<string, object>();
             }
 
@@ -2894,7 +2894,8 @@ namespace UnitySkills
                 {
                     added.Add(new
                     {
-                        instanceId = kvp.Key,
+                        entityId = GetPropertyValue<string>(kvp.Value, "entityId", null),
+                        instanceId = GetPropertyValue<int>(kvp.Value, "instanceId", 0),
                         name = GetPropertyValue<string>(kvp.Value, "name", ""),
                         path = GetPropertyValue<string>(kvp.Value, "path", "")
                     });
@@ -2908,7 +2909,8 @@ namespace UnitySkills
                 {
                     removed.Add(new
                     {
-                        instanceId = kvp.Key,
+                        entityId = kvp.Value["entityId"]?.ToString(),
+                        instanceId = kvp.Value["instanceId"]?.Value<int>() ?? 0,
                         name = kvp.Value["name"]?.ToString() ?? "",
                         path = kvp.Value["path"]?.ToString() ?? ""
                     });
@@ -2949,7 +2951,8 @@ namespace UnitySkills
                     {
                         modified.Add(new
                         {
-                            instanceId = kvp.Key,
+                            entityId = GetPropertyValue<string>(kvp.Value, "entityId", null),
+                            instanceId = GetPropertyValue<int>(kvp.Value, "instanceId", 0),
                             name = curName,
                             path = curPath,
                             changes = changes.ToArray()
@@ -3012,7 +3015,8 @@ namespace UnitySkills
 
             snapshot.Add(new Dictionary<string, object>
             {
-                ["instanceId"] = go.GetInstanceID(),
+                ["entityId"] = UnityObjectIdUtility.GetEntityId(go),
+                ["instanceId"] = UnityObjectIdUtility.GetObjectId(go),
                 ["name"] = go.name,
                 ["path"] = GameObjectFinder.GetPath(go),
                 ["componentList"] = string.Join(",", components),
@@ -3026,6 +3030,34 @@ namespace UnitySkills
             {
                 CaptureSceneSnapshotRecursive(t.GetChild(i).gameObject, activeScene, snapshot);
             }
+        }
+
+        private static string GetSnapshotIdentity(JObject item)
+        {
+            if (item == null)
+                return null;
+
+            var entityId = item["entityId"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(entityId))
+                return "entity:" + entityId.Trim();
+
+            var instanceId = item["instanceId"]?.Value<int>() ?? 0;
+            return instanceId != 0 ? "instance:" + instanceId.ToString(System.Globalization.CultureInfo.InvariantCulture) : null;
+        }
+
+        private static string GetSnapshotIdentity(object item)
+        {
+            if (item is IDictionary<string, object> dictionary)
+            {
+                var entityId = GetPropertyValue<string>(dictionary, "entityId", null);
+                if (!string.IsNullOrWhiteSpace(entityId))
+                    return "entity:" + entityId.Trim();
+
+                var instanceId = GetPropertyValue<int>(dictionary, "instanceId", 0);
+                return instanceId != 0 ? "instance:" + instanceId.ToString(System.Globalization.CultureInfo.InvariantCulture) : null;
+            }
+
+            return null;
         }
 
         private static bool HasVectorDifference(

--- a/SkillsForUnity/Editor/Skills/PhysicsSkills.cs
+++ b/SkillsForUnity/Editor/Skills/PhysicsSkills.cs
@@ -34,9 +34,11 @@ namespace UnitySkills
                 {
                     hit = true,
                     collider = hit.collider.name,
-                    colliderInstanceId = hit.collider.GetInstanceID(),
+                    colliderEntityId = UnityObjectIdUtility.GetEntityId(hit.collider),
+                    colliderInstanceId = UnityObjectIdUtility.GetObjectId(hit.collider),
                     objectName = hit.collider.gameObject.name,
-                    objectInstanceId = hit.collider.gameObject.GetInstanceID(),
+                    objectEntityId = UnityObjectIdUtility.GetEntityId(hit.collider.gameObject),
+                    objectInstanceId = UnityObjectIdUtility.GetObjectId(hit.collider.gameObject),
                     path = GameObjectFinder.GetPath(hit.collider.gameObject),
                     point = new { x = hit.point.x, y = hit.point.y, z = hit.point.z },
                     normal = new { x = hit.normal.x, y = hit.normal.y, z = hit.normal.z },
@@ -132,7 +134,8 @@ namespace UnitySkills
             var results = hits.OrderBy(h => h.distance).Select(h => new
             {
                 objectName = h.collider.gameObject.name,
-                instanceId = h.collider.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(h.collider.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(h.collider.gameObject),
                 path = GameObjectFinder.GetPath(h.collider.gameObject),
                 point = new { x = h.point.x, y = h.point.y, z = h.point.z },
                 normal = new { x = h.normal.x, y = h.normal.y, z = h.normal.z },
@@ -163,7 +166,8 @@ namespace UnitySkills
                 {
                     hit = true,
                     objectName = hit.collider.gameObject.name,
-                    instanceId = hit.collider.gameObject.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(hit.collider.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(hit.collider.gameObject),
                     point = new { x = hit.point.x, y = hit.point.y, z = hit.point.z },
                     distance = hit.distance
                 };
@@ -195,7 +199,8 @@ namespace UnitySkills
                 {
                     hit = true,
                     objectName = hit.collider.gameObject.name,
-                    instanceId = hit.collider.gameObject.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(hit.collider.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(hit.collider.gameObject),
                     point = new { x = hit.point.x, y = hit.point.y, z = hit.point.z },
                     distance = hit.distance
                 };

--- a/SkillsForUnity/Editor/Skills/PrefabSkills.cs
+++ b/SkillsForUnity/Editor/Skills/PrefabSkills.cs
@@ -76,7 +76,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(instance, "Instantiate Prefab");
             WorkflowManager.SnapshotObject(instance, SnapshotType.Created);
 
-            return new { success = true, name = instance.name, instanceId = instance.GetInstanceID(), path = GameObjectFinder.GetPath(instance) };
+            return new { success = true, name = instance.name, entityId = UnityObjectIdUtility.GetEntityId(instance), instanceId = UnityObjectIdUtility.GetObjectId(instance), path = GameObjectFinder.GetPath(instance) };
         }
 
         [UnitySkill("prefab_instantiate_batch", "Instantiate multiple prefabs (Efficient). items: JSON array of {prefabPath, x, y, z, name, rotX, rotY, rotZ, scaleX, scaleY, scaleZ, parentName, parentInstanceId, parentPath}",
@@ -140,7 +140,8 @@ namespace UnitySkills
                 {
                     success = true,
                     name = instance.name,
-                    instanceId = instance.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(instance),
+                    instanceId = UnityObjectIdUtility.GetObjectId(instance),
                     position = new { x = item.x, y = item.y, z = item.z }
                 };
             }, item => item.prefabPath);
@@ -333,7 +334,7 @@ namespace UnitySkills
             var instances = allObjects
                 .Where(go => PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(go) == prefabPath)
                 .Take(limit)
-                .Select(go => new { name = go.name, path = GameObjectFinder.GetPath(go), instanceId = go.GetInstanceID() })
+                .Select(go => new { name = go.name, path = GameObjectFinder.GetPath(go), entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go) })
                 .ToArray();
 
             return new { success = true, prefabPath, count = instances.Length, instances };

--- a/SkillsForUnity/Editor/Skills/ProBuilderSkills.cs
+++ b/SkillsForUnity/Editor/Skills/ProBuilderSkills.cs
@@ -60,7 +60,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 shape,
                 position = new { x, y, z },
                 size = new { x = sizeX, y = sizeY, z = sizeZ },
@@ -110,7 +111,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 extrudedFaceCount = newFaces?.Length ?? 0,
                 method,
                 distance,
@@ -160,7 +162,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 deletedCount = validIndices.Count,
                 remainingFaces = pbMesh.faceCount,
                 remainingVertices = pbMesh.vertexCount
@@ -201,7 +204,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 mergedFromCount = faces.Count,
                 totalFaces = pbMesh.faceCount,
                 totalVertices = pbMesh.vertexCount
@@ -241,7 +245,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 flippedCount = faces.Count
             };
 #endif
@@ -279,7 +284,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 detachedFaceCount = newFaces?.Count ?? 0,
                 deleteSourceFaces,
                 totalFaces = pbMesh.faceCount,
@@ -340,7 +346,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 beveledEdgeCount = edges.Count,
                 newFaceCount = newFaces?.Count ?? 0,
                 amount,
@@ -387,7 +394,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 extrudedEdgeCount = edges.Count,
                 newEdgeCount = newEdges?.Length ?? 0,
                 distance,
@@ -437,7 +445,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 bridgedEdge = new { a = edgeA, b = edgeB },
                 totalFaces = pbMesh.faceCount,
                 totalVertices = pbMesh.vertexCount
@@ -491,7 +500,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 totalFaces = pbMesh.faceCount,
                 totalVertices = pbMesh.vertexCount
             };
@@ -529,7 +539,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 status = result.status.ToString(),
                 notification = result.notification ?? "",
                 faceCount = faces.Count
@@ -580,7 +591,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 inputVertexCount = validIndices.Count,
                 weldedVertexCount = weldedIndices?.Length ?? 0,
                 radius,
@@ -664,7 +676,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 affectedFaces = faces.Count,
                 materialCount = pbMesh.GetComponent<MeshRenderer>().sharedMaterials.Length
             };
@@ -711,7 +724,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 isProBuilder = true,
                 vertexCount = pbMesh.vertexCount,
                 faceCount = pbMesh.faceCount,
@@ -764,7 +778,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 pivot = new { x = newPos.x, y = newPos.y, z = newPos.z }
             };
 #endif
@@ -811,7 +826,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 projectedFaceCount = faces.Count,
                 channel,
                 method = "Box"
@@ -940,7 +956,7 @@ namespace UnitySkills
                 Undo.RegisterCreatedObjectUndo(go, "Create PB Shape");
                 WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-                return new { success = true, name = go.name, instanceId = go.GetInstanceID(), shape = item.shape ?? "Cube" };
+                return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), shape = item.shape ?? "Cube" };
             }, item => item.name ?? item.shape);
 #endif
         }
@@ -1006,7 +1022,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 movedVertexCount = validIndices.Count,
                 delta = new { x = deltaX, y = deltaY, z = deltaZ },
                 totalVertices = pbMesh.vertexCount
@@ -1055,7 +1072,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 setVertexCount = setCount,
                 totalVertices = pbMesh.vertexCount
             };
@@ -1185,7 +1203,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = target.gameObject.name,
-                instanceId = target.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(target.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(target.gameObject),
                 combinedCount = meshes.Count,
                 resultMeshCount = result?.Count ?? 1,
                 vertexCount = target.vertexCount,
@@ -1246,7 +1265,8 @@ namespace UnitySkills
                 {
                     success = true,
                     name = pbMesh.gameObject.name,
-                    instanceId = pbMesh.gameObject.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                     materialName = mat.name,
                     color = new { r = color.r, g = color.g, b = color.b, a = color.a },
                     note = "Runtime material created. Use material_create + materialPath for persistent materials."
@@ -1261,7 +1281,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = pbMesh.gameObject.name,
-                instanceId = pbMesh.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(pbMesh.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(pbMesh.gameObject),
                 material = renderer.sharedMaterial.name
             };
 #endif

--- a/SkillsForUnity/Editor/Skills/ProjectSkills.cs
+++ b/SkillsForUnity/Editor/Skills/ProjectSkills.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.Build;
 using UnityEngine.Rendering;
 using System.IO;
 using System.Linq;
@@ -366,8 +367,8 @@ namespace UnitySkills
                 defaultScreenWidth = PlayerSettings.defaultScreenWidth,
                 defaultScreenHeight = PlayerSettings.defaultScreenHeight,
                 fullscreen = PlayerSettings.fullScreenMode.ToString(),
-                apiCompatibility = PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.selectedBuildTargetGroup).ToString(),
-                scriptingBackend = PlayerSettings.GetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup).ToString()
+                apiCompatibility = PlayerSettings.GetApiCompatibilityLevel(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup)).ToString(),
+                scriptingBackend = PlayerSettings.GetScriptingBackend(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup)).ToString()
             };
         }
 

--- a/SkillsForUnity/Editor/Skills/RenderPipelineSkillsCommon.cs
+++ b/SkillsForUnity/Editor/Skills/RenderPipelineSkillsCommon.cs
@@ -196,7 +196,8 @@ namespace UnitySkills
             {
                 name = asset.name,
                 path = string.IsNullOrEmpty(path) ? null : path,
-                instanceId = asset.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(asset),
+                instanceId = UnityObjectIdUtility.GetObjectId(asset),
                 type = asset.GetType().Name
             };
         }

--- a/SkillsForUnity/Editor/Skills/SampleSkills.cs
+++ b/SkillsForUnity/Editor/Skills/SampleSkills.cs
@@ -21,7 +21,7 @@ namespace UnitySkills
             cube.transform.position = new Vector3(x, y, z);
             Undo.RegisterCreatedObjectUndo(cube, "Create " + name);
             WorkflowManager.SnapshotObject(cube, SnapshotType.Created);
-            return new { success = true, name = cube.name, instanceId = cube.GetInstanceID(), position = new { x, y, z }, message = $"Created {name} at ({x},{y},{z})" };
+            return new { success = true, name = cube.name, entityId = UnityObjectIdUtility.GetEntityId(cube), instanceId = UnityObjectIdUtility.GetObjectId(cube), position = new { x, y, z }, message = $"Created {name} at ({x},{y},{z})" };
         }
 
         [UnitySkill("create_sphere", "Create a sphere at the specified position",
@@ -35,7 +35,7 @@ namespace UnitySkills
             sphere.transform.position = new Vector3(x, y, z);
             Undo.RegisterCreatedObjectUndo(sphere, "Create " + name);
             WorkflowManager.SnapshotObject(sphere, SnapshotType.Created);
-            return new { success = true, name = sphere.name, instanceId = sphere.GetInstanceID(), position = new { x, y, z }, message = $"Created {name} at ({x},{y},{z})" };
+            return new { success = true, name = sphere.name, entityId = UnityObjectIdUtility.GetEntityId(sphere), instanceId = UnityObjectIdUtility.GetObjectId(sphere), position = new { x, y, z }, message = $"Created {name} at ({x},{y},{z})" };
         }
 
         [UnitySkill("delete_object", "Delete a GameObject by name",

--- a/SkillsForUnity/Editor/Skills/SceneSkills.cs
+++ b/SkillsForUnity/Editor/Skills/SceneSkills.cs
@@ -92,7 +92,8 @@ namespace UnitySkills
                 rootObjects = roots.Select(go => new
                 {
                     name = go.name,
-                    instanceId = go.GetInstanceID(),
+                    entityId = UnityObjectIdUtility.GetEntityId(go),
+                    instanceId = UnityObjectIdUtility.GetObjectId(go),
                     childCount = go.transform.childCount
                 }).ToArray()
             };
@@ -135,7 +136,8 @@ namespace UnitySkills
             var node = new
             {
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 components = GetComponentTypeNames(go, componentBuffer),
                 children
             };
@@ -293,7 +295,7 @@ namespace UnitySkills
             }
 
             var results = objects.Take(limit).Select(go => new {
-                name = go.name, path = GameObjectFinder.GetCachedPath(go), instanceId = go.GetInstanceID(),
+                name = go.name, path = GameObjectFinder.GetCachedPath(go), entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go),
                 active = go.activeInHierarchy, tag = go.tag
             }).ToArray();
 

--- a/SkillsForUnity/Editor/Skills/SerializedPropertySkillUtility.cs
+++ b/SkillsForUnity/Editor/Skills/SerializedPropertySkillUtility.cs
@@ -331,7 +331,7 @@ namespace UnitySkills
                 case SerializedPropertyType.ObjectReference:
                     return property.objectReferenceValue == null
                         ? "null"
-                        : $"{property.objectReferenceValue.GetInstanceID()}:{property.objectReferenceValue.GetType().FullName}:{property.objectReferenceValue.name}";
+                        : $"{UnityObjectIdUtility.GetEntityId(property.objectReferenceValue)}:{property.objectReferenceValue.GetType().FullName}:{property.objectReferenceValue.name}";
                 case SerializedPropertyType.Enum:
                     return property.enumValueIndex.ToString(CultureInfo.InvariantCulture);
                 case SerializedPropertyType.Vector2:

--- a/SkillsForUnity/Editor/Skills/ShaderGraphReflectionHelper.cs
+++ b/SkillsForUnity/Editor/Skills/ShaderGraphReflectionHelper.cs
@@ -2339,14 +2339,28 @@ namespace UnitySkills
             foreach (var method in methods)
             {
                 var parameters = method.GetParameters();
-                if (parameters.Length != arguments.Length)
+                if (arguments.Length > parameters.Length)
+                    continue;
+                if (parameters.Skip(arguments.Length).Any(parameter => !parameter.IsOptional))
                     continue;
 
                 try
                 {
-                    var invokeArguments = new object[arguments.Length];
+                    var invokeArguments = new object[parameters.Length];
                     for (var i = 0; i < parameters.Length; i++)
-                        invokeArguments[i] = ChangeType(arguments[i], parameters[i].ParameterType);
+                    {
+                        if (i < arguments.Length)
+                        {
+                            invokeArguments[i] = ChangeType(arguments[i], parameters[i].ParameterType);
+                        }
+                        else
+                        {
+                            invokeArguments[i] = parameters[i].DefaultValue == DBNull.Value
+                                ? Type.Missing
+                                : parameters[i].DefaultValue;
+                        }
+                    }
+
                     return method.Invoke(instance, invokeArguments);
                 }
                 catch

--- a/SkillsForUnity/Editor/Skills/ShaderSkills.cs
+++ b/SkillsForUnity/Editor/Skills/ShaderSkills.cs
@@ -130,7 +130,7 @@ namespace UnitySkills
                     {
                         path = p,
                         name = shader?.name,
-                        propertyCount = shader != null ? ShaderUtil.GetPropertyCount(shader) : 0
+                        propertyCount = shader != null ? shader.GetPropertyCount() : 0
                     };
                 })
                 .ToArray();
@@ -151,13 +151,13 @@ namespace UnitySkills
             if (shader == null)
                 return new { error = $"Shader not found: {shaderNameOrPath}" };
 
-            var propCount = ShaderUtil.GetPropertyCount(shader);
+            var propCount = shader.GetPropertyCount();
             var properties = Enumerable.Range(0, propCount)
                 .Select(i => new
                 {
-                    name = ShaderUtil.GetPropertyName(shader, i),
-                    type = ShaderUtil.GetPropertyType(shader, i).ToString(),
-                    description = ShaderUtil.GetPropertyDescription(shader, i)
+                    name = shader.GetPropertyName(i),
+                    type = shader.GetPropertyType(i).ToString(),
+                    description = shader.GetPropertyDescription(i)
                 })
                 .ToArray();
 

--- a/SkillsForUnity/Editor/Skills/SkillRouter.cs
+++ b/SkillsForUnity/Editor/Skills/SkillRouter.cs
@@ -94,6 +94,29 @@ namespace UnitySkills
             "_confirm"
         };
 
+        private const string EntityIdParameterName = "entityId";
+
+        private static readonly string[] _entityIdPathFallbackParameters =
+        {
+            "path",
+            "targetPath",
+            "cameraPath",
+            "vcamPath",
+            "sequencerPath"
+        };
+
+        private static readonly string[] _entityIdNameFallbackParameters =
+        {
+            "name",
+            "target",
+            "targetName",
+            "cameraName",
+            "vcamName",
+            "sequencerName",
+            "objectName",
+            "gameObjectName"
+        };
+
         private static readonly HashSet<string> _transactionlessSkills = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "editor_undo",
@@ -324,6 +347,8 @@ namespace UnitySkills
                             var parameterNames = parameters.Select(p => p.Name).ToArray();
                             var allowedSet = new HashSet<string>(parameterNames, StringComparer.OrdinalIgnoreCase);
                             allowedSet.UnionWith(_reservedBodyParameters);
+                            if (!allowedSet.Contains(EntityIdParameterName) && SupportsSyntheticEntityId(parameterNames))
+                                allowedSet.Add(EntityIdParameterName);
                             skills[name] = new SkillInfo
                             {
                                 Name = name,
@@ -364,8 +389,9 @@ namespace UnitySkills
                 var outputIdx = new Dictionary<string, List<SkillInfo>>(StringComparer.OrdinalIgnoreCase);
                 foreach (var s in skills.Values)
                 {
-                    if (s.Outputs == null) continue;
-                    foreach (var output in s.Outputs)
+                    var effectiveOutputs = GetEffectiveOutputs(s);
+                    if (effectiveOutputs == null) continue;
+                    foreach (var output in effectiveOutputs)
                     {
                         if (!outputIdx.TryGetValue(output, out var list))
                         {
@@ -442,7 +468,7 @@ namespace UnitySkills
                         SkillErrorCode.UnknownParam,
                         $"Unknown parameters: {string.Join(", ", ExtractValidationParameterNames(validation.UnknownParams))}",
                         skill: name,
-                        details: new { unknownParams = validation.UnknownParams.ToArray(), allowedParams = skill.ParameterNames },
+                        details: new { unknownParams = validation.UnknownParams.ToArray(), allowedParams = GetEffectiveParameterNames(skill) },
                         suggestedFixes: fixes,
                         retryStrategy: SkillErrorResponse.RetryFixAndRetry);
                 }
@@ -453,7 +479,7 @@ namespace UnitySkills
                         SkillErrorCode.MissingParam,
                         $"Missing required parameter: {validation.MissingParams[0]}",
                         skill: name,
-                        details: new { missingParams = validation.MissingParams.ToArray(), allowedParams = skill.ParameterNames },
+                        details: new { missingParams = validation.MissingParams.ToArray(), allowedParams = GetEffectiveParameterNames(skill) },
                         retryStrategy: SkillErrorResponse.RetryFixAndRetry);
                 }
 
@@ -662,11 +688,11 @@ namespace UnitySkills
                     skill = new
                     {
                         name = skill.Name,
-                        description = skill.Description,
+                        description = GetEffectiveDescription(skill),
                         category = skill.Category != SkillCategory.Uncategorized ? skill.Category.ToString() : null,
                         operation = FormatOperation(skill.Operation),
                         tags = skill.Tags,
-                        outputs = skill.Outputs,
+                        outputs = GetEffectiveOutputs(skill),
                         requiresInput = skill.RequiresInput,
                         readOnly = skill.ReadOnly,
                         tracksWorkflow = skill.TracksWorkflow,
@@ -717,11 +743,12 @@ namespace UnitySkills
 
         private static string SerializeSuccessResponse(object result)
         {
+            var jsonResult = NormalizeSuccessResult(result);
+
             if (ServerAvailabilityHelper.IsCompilationInProgress())
             {
                 try
                 {
-                    var jsonResult = JToken.FromObject(result ?? new object());
                     if (jsonResult is JObject obj && !obj.ContainsKey("serverAvailability"))
                     {
                         var notice = ServerAvailabilityHelper.CreateTransientUnavailableNotice(
@@ -736,7 +763,191 @@ namespace UnitySkills
                 }
                 catch { }
             }
-            return JsonConvert.SerializeObject(new { status = "success", result }, _jsonSettings);
+
+            return JsonConvert.SerializeObject(new { status = "success", result = jsonResult }, _jsonSettings);
+        }
+
+        private static JToken NormalizeSuccessResult(object result)
+        {
+            try
+            {
+                var token = result is JToken existingToken
+                    ? existingToken.DeepClone()
+                    : JToken.FromObject(result ?? new object(), JsonSerializer.Create(_jsonSettings));
+
+                AddEntityIdsToResult(token);
+                return token;
+            }
+            catch
+            {
+                return result is JToken fallbackToken
+                    ? fallbackToken.DeepClone()
+                    : JToken.FromObject(result ?? new object());
+            }
+        }
+
+        private static void AddEntityIdsToResult(JToken token)
+        {
+            if (token == null)
+                return;
+
+            if (token is JObject obj)
+            {
+                TryAddEntityIdToResultObject(obj);
+                foreach (var property in obj.Properties().ToArray())
+                    AddEntityIdsToResult(property.Value);
+                return;
+            }
+
+            if (token is JArray array)
+            {
+                foreach (var item in array)
+                    AddEntityIdsToResult(item);
+            }
+        }
+
+        private static void TryAddEntityIdToResultObject(JObject obj)
+        {
+            if (obj == null ||
+                TryGetJsonValue(obj, EntityIdParameterName, out _) ||
+                !TryGetJsonValue(obj, "instanceId", out var instanceIdToken))
+            {
+                return;
+            }
+
+            var unityObject = ResolveUnityObjectFromResultObject(obj, instanceIdToken);
+            var entityId = UnityObjectIdUtility.GetEntityId(unityObject);
+            if (!string.IsNullOrWhiteSpace(entityId))
+                obj[EntityIdParameterName] = entityId;
+        }
+
+        private static UnityEngine.Object ResolveUnityObjectFromResultObject(JObject obj, JToken instanceIdToken)
+        {
+            if (TryReadInt(instanceIdToken, out var instanceId) && instanceId != 0)
+            {
+                var byInstanceId = UnityObjectIdUtility.ObjectIdToObject(instanceId);
+                if (byInstanceId != null)
+                    return byInstanceId;
+            }
+
+            foreach (var pathField in new[] { "assetPath", "materialPath", "profilePath", "prefabPath", "path" })
+            {
+                if (!TryGetJsonString(obj, pathField, out var candidatePath))
+                    continue;
+
+                var asset = TryResolveAssetPath(candidatePath);
+                if (asset != null)
+                    return asset;
+
+                var sceneObject = TryResolveScenePath(candidatePath);
+                if (sceneObject != null)
+                    return sceneObject;
+            }
+
+            foreach (var nameField in new[] { "gameObject", "gameObjectName", "target", "targetName", "objectName", "cameraName", "vcamName", "sequencerName" })
+            {
+                if (!TryGetJsonString(obj, nameField, out var candidateName))
+                    continue;
+
+                var sceneObject = GameObjectFinder.Find(name: candidateName);
+                if (sceneObject != null)
+                    return sceneObject;
+            }
+
+            if (!LooksLikeAssetResult(obj) && TryGetJsonString(obj, "name", out var name))
+                return GameObjectFinder.Find(name: name);
+
+            return null;
+        }
+
+        private static UnityEngine.Object TryResolveAssetPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            var normalized = path.Replace('\\', '/');
+            if (!normalized.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase) &&
+                !normalized.StartsWith("Packages/", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(normalized);
+        }
+
+        private static GameObject TryResolveScenePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            var normalized = path.Replace('\\', '/');
+            if (normalized.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase) ||
+                normalized.StartsWith("Packages/", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return GameObjectFinder.Find(path: normalized);
+        }
+
+        private static bool LooksLikeAssetResult(JObject obj)
+        {
+            return TryGetJsonValue(obj, "assetPath", out _) ||
+                TryGetJsonValue(obj, "materialPath", out _) ||
+                TryGetJsonValue(obj, "profilePath", out _) ||
+                TryGetJsonValue(obj, "prefabPath", out _) ||
+                TryGetJsonValue(obj, "shader", out _) ||
+                TryGetJsonValue(obj, "texture", out _) ||
+                TryGetJsonValue(obj, "renderPipeline", out _);
+        }
+
+        private static bool TryGetJsonString(JObject obj, string propertyName, out string value)
+        {
+            value = null;
+            if (!TryGetJsonValue(obj, propertyName, out var token) ||
+                token == null ||
+                token.Type == JTokenType.Null)
+            {
+                return false;
+            }
+
+            value = token.ToString();
+            return !string.IsNullOrWhiteSpace(value);
+        }
+
+        private static bool TryGetJsonValue(JObject obj, string propertyName, out JToken value)
+        {
+            value = null;
+            if (obj == null || string.IsNullOrEmpty(propertyName))
+                return false;
+
+            foreach (var property in obj.Properties())
+            {
+                if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryReadInt(JToken token, out int value)
+        {
+            value = 0;
+            if (token == null || token.Type == JTokenType.Null)
+                return false;
+
+            try
+            {
+                value = token.ToObject<int>();
+                return true;
+            }
+            catch
+            {
+                return int.TryParse(token.ToString(), out value);
+            }
         }
 
         public static void Refresh()
@@ -841,6 +1052,98 @@ namespace UnitySkills
             return JsonConvert.SerializeObject(manifest, _jsonSettings);
         }
 
+        private static bool ContainsParameter(IEnumerable<string> parameterNames, string parameterName)
+        {
+            return parameterNames != null &&
+                parameterNames.Any(name => string.Equals(name, parameterName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool SupportsSyntheticEntityId(string[] parameterNames)
+        {
+            return !ContainsParameter(parameterNames, EntityIdParameterName) &&
+                ContainsParameter(parameterNames, "instanceId") &&
+                (_entityIdPathFallbackParameters.Any(name => ContainsParameter(parameterNames, name)) ||
+                 _entityIdNameFallbackParameters.Any(name => ContainsParameter(parameterNames, name)));
+        }
+
+        private static bool ShouldExposeSyntheticEntityId(SkillInfo skill)
+        {
+            return skill != null &&
+                !ContainsParameter(skill.ParameterNames, EntityIdParameterName) &&
+                skill.AllowedParameterSet != null &&
+                skill.AllowedParameterSet.Contains(EntityIdParameterName);
+        }
+
+        private static string[] GetEffectiveParameterNames(SkillInfo skill)
+        {
+            if (skill?.ParameterNames == null)
+                return Array.Empty<string>();
+
+            if (!ShouldExposeSyntheticEntityId(skill))
+                return skill.ParameterNames;
+
+            return skill.ParameterNames
+                .Concat(new[] { EntityIdParameterName })
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static object[] BuildParameterSchema(SkillInfo skill)
+        {
+            if (skill == null)
+                return Array.Empty<object>();
+
+            var parameters = skill.Parameters.Select(p => (object)new
+            {
+                name = p.Name,
+                type = GetJsonType(p.ParameterType),
+                required = IsParameterRequired(p),
+                defaultValue = p.HasDefaultValue ? p.DefaultValue?.ToString() : null
+            }).ToList();
+
+            if (ShouldExposeSyntheticEntityId(skill))
+            {
+                parameters.Add(new
+                {
+                    name = EntityIdParameterName,
+                    type = "string",
+                    required = false,
+                    defaultValue = (string)null
+                });
+            }
+
+            return parameters.ToArray();
+        }
+
+        private static string[] GetEffectiveOutputs(SkillInfo skill)
+        {
+            if (skill?.Outputs == null)
+                return null;
+
+            if (!skill.Outputs.Any(output => string.Equals(output, "instanceId", StringComparison.OrdinalIgnoreCase)) ||
+                skill.Outputs.Any(output => string.Equals(output, EntityIdParameterName, StringComparison.OrdinalIgnoreCase)))
+            {
+                return skill.Outputs;
+            }
+
+            return skill.Outputs
+                .Concat(new[] { EntityIdParameterName })
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static string GetEffectiveDescription(SkillInfo skill)
+        {
+            var description = skill?.Description ?? string.Empty;
+            if (!ShouldExposeSyntheticEntityId(skill))
+                return description;
+
+            return description
+                .Replace("name/instanceId/path", "name/entityId/instanceId/path")
+                .Replace("name, instanceId, or path", "name, entityId, instanceId, or path")
+                .Replace("name / instanceId / path", "name / entityId / instanceId / path");
+        }
+
         private static object BuildManifest(IEnumerable<SkillInfo> skills, bool filtered, Dictionary<string, string> filters, string manifestType)
         {
             var skillArray = skills
@@ -863,11 +1166,11 @@ namespace UnitySkills
                 skills = skillArray.Select(s => new
                 {
                     name = s.Name,
-                    description = s.Description,
+                    description = GetEffectiveDescription(s),
                     category = s.Category != SkillCategory.Uncategorized ? s.Category.ToString() : null,
                     operation = FormatOperation(s.Operation),
                     tags = s.Tags,
-                    outputs = s.Outputs,
+                    outputs = GetEffectiveOutputs(s),
                     requiresInput = s.RequiresInput,
                     readOnly = s.ReadOnly,
                     tracksWorkflow = s.TracksWorkflow,
@@ -880,13 +1183,7 @@ namespace UnitySkills
                     requiresPackages = s.RequiresPackages,
                     mode = SkillsModeManager.SkillModeToWire(s.Mode),
                     approvalBehavior = SkillsModeManager.ApprovalBehaviorForSkill(s),
-                    parameters = s.Parameters.Select(p => new
-                    {
-                        name = p.Name,
-                        type = GetJsonType(p.ParameterType),
-                        required = IsParameterRequired(p),
-                        defaultValue = p.HasDefaultValue ? p.DefaultValue?.ToString() : null
-                    })
+                    parameters = BuildParameterSchema(s)
                 })
             };
         }
@@ -988,7 +1285,7 @@ namespace UnitySkills
                 results = results.Select(x => new
                 {
                     name = x.skill.Name,
-                    description = x.skill.Description,
+                    description = GetEffectiveDescription(x.skill),
                     category = x.skill.Category != SkillCategory.Uncategorized ? x.skill.Category.ToString() : null,
                     score = x.score,
                     confidence = ScoreToConfidence(x.score),
@@ -1008,14 +1305,8 @@ namespace UnitySkills
 
         private static object BuildSkillSchemaForRecommend(SkillInfo s) => new
         {
-            parameters = s.Parameters.Select(p => new
-            {
-                name = p.Name,
-                type = GetJsonType(p.ParameterType),
-                required = IsParameterRequired(p),
-                defaultValue = p.HasDefaultValue ? p.DefaultValue?.ToString() : null
-            }).ToArray(),
-            outputs = s.Outputs,
+            parameters = BuildParameterSchema(s),
+            outputs = GetEffectiveOutputs(s),
             requiresInput = s.RequiresInput,
             tags = s.Tags,
             operation = FormatOperation(s.Operation),
@@ -1074,11 +1365,11 @@ namespace UnitySkills
                     producers.Add(new
                     {
                         skill = s.Name,
-                        description = s.Description,
+                        description = GetEffectiveDescription(s),
                         category = s.Category != SkillCategory.Uncategorized ? s.Category.ToString() : null,
                         depth,
                         producesField = field,
-                        outputs = s.Outputs,
+                        outputs = GetEffectiveOutputs(s),
                         requiresInput = s.RequiresInput
                     });
 
@@ -1153,6 +1444,7 @@ namespace UnitySkills
             };
 
             var ps = skill.Parameters;
+            NormalizeSyntheticEntityIdLocator(skill, validation);
             CollectUnknownParameters(skill, validation);
             var invoke = new object[ps.Length];
             for (int i = 0; i < ps.Length; i++)
@@ -1194,9 +1486,70 @@ namespace UnitySkills
                 });
             }
 
+            if (ShouldExposeSyntheticEntityId(skill))
+            {
+                validation.ParameterDetails.Add(new
+                {
+                    name = EntityIdParameterName,
+                    type = "string",
+                    required = false,
+                    provided = validation.Args.TryGetValue(EntityIdParameterName, StringComparison.OrdinalIgnoreCase, out _),
+                    defaultValue = (string)null,
+                    synthetic = true
+                });
+            }
+
             validation.InvokeArgs = invoke;
             SkillPlanningService.ApplySemanticValidation(skill, validation);
             return validation;
+        }
+
+        private static void NormalizeSyntheticEntityIdLocator(SkillInfo skill, ParameterValidationResult validation)
+        {
+            if (!ShouldExposeSyntheticEntityId(skill) ||
+                validation?.Args == null ||
+                !validation.Args.TryGetValue(EntityIdParameterName, StringComparison.OrdinalIgnoreCase, out var token))
+            {
+                return;
+            }
+
+            var entityId = token.Type == JTokenType.Null ? null : token.ToString();
+            if (string.IsNullOrWhiteSpace(entityId))
+                return;
+
+            var unityObject = UnityObjectIdUtility.EntityIdToObject(entityId);
+            var gameObject = unityObject as GameObject ?? (unityObject as Component)?.gameObject;
+            if (gameObject == null)
+            {
+                validation.SemanticErrors.Add(new
+                {
+                    parameter = EntityIdParameterName,
+                    error = $"Object not found for entityId: {entityId}"
+                });
+                return;
+            }
+
+            if (TryInjectLocatorValue(validation.Args, skill.ParameterNames, _entityIdPathFallbackParameters, GameObjectFinder.GetCachedPath(gameObject)))
+                return;
+
+            TryInjectLocatorValue(validation.Args, skill.ParameterNames, _entityIdNameFallbackParameters, gameObject.name);
+        }
+
+        private static bool TryInjectLocatorValue(JObject args, string[] parameterNames, string[] candidates, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            foreach (var candidate in candidates)
+            {
+                if (!ContainsParameter(parameterNames, candidate))
+                    continue;
+
+                args[candidate] = value;
+                return true;
+            }
+
+            return false;
         }
 
         private static void CollectUnknownParameters(SkillInfo skill, ParameterValidationResult validation)
@@ -1631,6 +1984,7 @@ namespace UnitySkills
                 string targetName = null;
                 int targetInstanceId = 0;
                 string targetPath = null;
+                string targetEntityId = null;
 
                 if (args.TryGetValue("name", StringComparison.OrdinalIgnoreCase, out var nameToken))
                     targetName = nameToken.ToString();
@@ -1638,11 +1992,13 @@ namespace UnitySkills
                     targetInstanceId = idToken.ToObject<int>();
                 if (args.TryGetValue("path", StringComparison.OrdinalIgnoreCase, out var pathToken))
                     targetPath = pathToken.ToString();
+                if (args.TryGetValue(EntityIdParameterName, StringComparison.OrdinalIgnoreCase, out var entityIdToken))
+                    targetEntityId = entityIdToken.ToString();
 
                 // Snapshot GameObject if identifiable
-                if (!string.IsNullOrEmpty(targetName) || targetInstanceId != 0 || !string.IsNullOrEmpty(targetPath))
+                if (!string.IsNullOrEmpty(targetEntityId) || !string.IsNullOrEmpty(targetName) || targetInstanceId != 0 || !string.IsNullOrEmpty(targetPath))
                 {
-                    var (go, _) = GameObjectFinder.FindOrError(targetName, targetInstanceId, targetPath);
+                    var (go, _) = GameObjectFinder.FindOrError(targetName, targetInstanceId, targetPath, entityId: targetEntityId);
                     if (go != null)
                     {
                         WorkflowManager.SnapshotObject(go);
@@ -1700,10 +2056,11 @@ namespace UnitySkills
                                 string itemName = item.ContainsKey("name") ? item["name"]?.ToString() : null;
                                 int itemId = item.ContainsKey("instanceId") ? Convert.ToInt32(item["instanceId"]) : 0;
                                 string itemPath = item.ContainsKey("path") ? item["path"]?.ToString() : null;
+                                string itemEntityId = item.ContainsKey(EntityIdParameterName) ? item[EntityIdParameterName]?.ToString() : null;
 
-                                if (!string.IsNullOrEmpty(itemName) || itemId != 0 || !string.IsNullOrEmpty(itemPath))
+                                if (!string.IsNullOrEmpty(itemEntityId) || !string.IsNullOrEmpty(itemName) || itemId != 0 || !string.IsNullOrEmpty(itemPath))
                                 {
-                                    var (itemGo, _) = GameObjectFinder.FindOrError(itemName, itemId, itemPath);
+                                    var (itemGo, _) = GameObjectFinder.FindOrError(itemName, itemId, itemPath, entityId: itemEntityId);
                                     if (itemGo != null)
                                     {
                                         WorkflowManager.SnapshotObject(itemGo);

--- a/SkillsForUnity/Editor/Skills/SkillsLogger.cs
+++ b/SkillsForUnity/Editor/Skills/SkillsLogger.cs
@@ -14,7 +14,7 @@ namespace UnitySkills
         /// Centralized version constant. Update this when releasing a new version.
         /// Referenced by SkillsHttpServer (/health), SkillRouter (/skills manifest), and docs tooling.
         /// </summary>
-        public const string Version = "2.0.3";
+        public const string Version = "2.0.4";
 
         public const string PREFIX_INFO = "<color=#4A9EFF>[UnitySkills]</color>";
         public const string PREFIX_SUCCESS = "<color=#5EE05E>[UnitySkills]</color>";

--- a/SkillsForUnity/Editor/Skills/SmartSkills.cs
+++ b/SkillsForUnity/Editor/Skills/SmartSkills.cs
@@ -65,7 +65,7 @@ namespace UnitySkills
             if (type == null) 
                 return new { success = false, error = $"Component type '{componentName}' not found. Try: Light, MeshRenderer, Camera, etc." };
 
-            var components = Object.FindObjectsOfType(type);
+            var components = FindHelper.FindAll(type, includeInactive: false);
             
             foreach (var comp in components)
             {
@@ -81,7 +81,8 @@ namespace UnitySkills
                     results.Add(new 
                     {
                         name = go.name,
-                        instanceId = go.GetInstanceID(),
+                        entityId = UnityObjectIdUtility.GetEntityId(go),
+                        instanceId = UnityObjectIdUtility.GetObjectId(go),
                         path = GameObjectFinder.GetPath(go),
                         propertyValue = FormatValue(val)
                     });
@@ -409,7 +410,7 @@ namespace UnitySkills
                 }
                 results.Add(new
                 {
-                    name = go.name, instanceId = go.GetInstanceID(),
+                    name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go),
                     path = GameObjectFinder.GetPath(go),
                     distance = Vector3.Distance(center, go.transform.position)
                 });
@@ -547,7 +548,7 @@ namespace UnitySkills
 
             var type = GetTypeByName(componentName);
             if (type == null) return new { error = $"Component type '{componentName}' not found" };
-            var components = Object.FindObjectsOfType(type);
+            var components = FindHelper.FindAll(type, includeInactive: false);
             var gameObjects = components.OfType<Component>().Select(c => c.gameObject).Distinct().ToArray();
             Selection.objects = gameObjects;
             return new { success = true, selected = gameObjects.Length, component = componentName };

--- a/SkillsForUnity/Editor/Skills/TerrainSkills.cs
+++ b/SkillsForUnity/Editor/Skills/TerrainSkills.cs
@@ -45,7 +45,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = terrainGO.name,
-                instanceId = terrainGO.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(terrainGO),
+                instanceId = UnityObjectIdUtility.GetObjectId(terrainGO),
                 terrainDataPath = assetPath,
                 size = new { width, length, height },
                 position = new { x, y, z }
@@ -88,7 +89,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = terrain.name,
-                instanceId = terrain.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(terrain.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(terrain.gameObject),
                 position = new { x = terrain.transform.position.x, y = terrain.transform.position.y, z = terrain.transform.position.z },
                 size = new { width = data.size.x, height = data.size.y, length = data.size.z },
                 heightmapResolution = data.heightmapResolution,
@@ -579,7 +581,7 @@ namespace UnitySkills
         {
             if (instanceId != 0)
             {
-                var obj = EditorUtility.InstanceIDToObject(instanceId) as GameObject;
+                var obj = UnityObjectIdUtility.ObjectIdToObject(instanceId) as GameObject;
                 return obj?.GetComponent<Terrain>();
             }
 
@@ -590,7 +592,7 @@ namespace UnitySkills
             }
 
             // Return first terrain in scene
-            return Object.FindObjectOfType<Terrain>();
+            return Object.FindAnyObjectByType<Terrain>();
         }
     }
 }

--- a/SkillsForUnity/Editor/Skills/TimelineSkills.cs
+++ b/SkillsForUnity/Editor/Skills/TimelineSkills.cs
@@ -40,12 +40,13 @@ namespace UnitySkills
 
             AssetDatabase.SaveAssets();
             
-            return new 
-            { 
-                success = true, 
-                assetPath, 
-                gameObjectName = go.name, 
-                directorInstanceId = director.GetInstanceID() 
+            return new
+            {
+                success = true,
+                assetPath,
+                gameObjectName = go.name,
+                directorEntityId = UnityObjectIdUtility.GetEntityId(director),
+                directorInstanceId = UnityObjectIdUtility.GetObjectId(director)
             };
         }
 

--- a/SkillsForUnity/Editor/Skills/UISkills.cs
+++ b/SkillsForUnity/Editor/Skills/UISkills.cs
@@ -136,7 +136,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 renderMode = canvas.renderMode.ToString()
             };
         }
@@ -166,7 +167,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Panel");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name };
         }
 
         [UnitySkill("ui_create_button", "Create a Button UI element",
@@ -204,7 +205,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Button");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, text };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, text };
         }
 
         [UnitySkill("ui_create_text", "Create a Text UI element",
@@ -229,7 +230,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Text");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, usingTMP = IsTMPAvailable() };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, usingTMP = IsTMPAvailable() };
         }
 
         [UnitySkill("ui_create_image", "Create an Image UI element",
@@ -261,7 +262,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Image");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name };
         }
 
         [UnitySkill("ui_create_batch", "Create multiple UI elements (Efficient). items: JSON array of {type, name, parent, text, width, height, ...}",
@@ -452,7 +453,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create InputField");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, placeholder, usingTMP = IsTMPAvailable() };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, placeholder, usingTMP = IsTMPAvailable() };
         }
 
         [UnitySkill("ui_create_slider", "Create a Slider UI element",
@@ -525,7 +526,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Slider");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, minValue, maxValue, value };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, minValue, maxValue, value };
         }
 
         [UnitySkill("ui_create_toggle", "Create a Toggle UI element",
@@ -586,7 +587,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Toggle");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, label, isOn };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, label, isOn };
         }
 
         [UnitySkill("ui_set_text", "Set text content on a UI Text element (supports name/instanceId/path)",
@@ -651,7 +652,8 @@ namespace UnitySkills
                     results.Add(new
                     {
                         name = element.name,
-                        instanceId = element.gameObject.GetInstanceID(),
+                        entityId = UnityObjectIdUtility.GetEntityId(element.gameObject),
+                        instanceId = UnityObjectIdUtility.GetObjectId(element.gameObject),
                         path = GameObjectFinder.GetCachedPath(element.gameObject),
                         uiType = type,
                         active = element.gameObject.activeInHierarchy
@@ -671,7 +673,7 @@ namespace UnitySkills
             }
 
             // Find existing canvas
-            var canvas = UnityEngine.Object.FindObjectOfType<Canvas>();
+            var canvas = UnityEngine.Object.FindAnyObjectByType<Canvas>();
             if (canvas != null) return canvas.gameObject;
 
             // Create new canvas
@@ -1268,7 +1270,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Dropdown");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, optionCount = optionList.Count };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, optionCount = optionList.Count };
         }
 
         [UnitySkill("ui_create_scrollview", "Create a ScrollRect (ScrollView) UI element",
@@ -1327,7 +1329,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create ScrollView");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, horizontal, vertical };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, horizontal, vertical };
         }
 
         [UnitySkill("ui_create_rawimage", "Create a RawImage UI element (for Texture2D/RenderTexture)",
@@ -1359,7 +1361,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create RawImage");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, hasTexture = rawImage.texture != null };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, hasTexture = rawImage.texture != null };
         }
 
         [UnitySkill("ui_create_scrollbar", "Create a standalone Scrollbar UI element",
@@ -1415,7 +1417,7 @@ namespace UnitySkills
             Undo.RegisterCreatedObjectUndo(go, "Create Scrollbar");
             WorkflowManager.SnapshotObject(go, SnapshotType.Created);
 
-            return new { success = true, name = go.name, instanceId = go.GetInstanceID(), parent = parentGo.name, direction };
+            return new { success = true, name = go.name, entityId = UnityObjectIdUtility.GetEntityId(go), instanceId = UnityObjectIdUtility.GetObjectId(go), parent = parentGo.name, direction };
         }
 
         // ==================================================================================
@@ -1748,7 +1750,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetPath(go),
                 anchorMin = ToObject(rect.anchorMin),
                 anchorMax = ToObject(rect.anchorMax),

--- a/SkillsForUnity/Editor/Skills/UIToolkitSkills.cs
+++ b/SkillsForUnity/Editor/Skills/UIToolkitSkills.cs
@@ -253,7 +253,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 hasUxml = doc.visualTreeAsset != null,
                 hasPanelSettings = doc.panelSettings != null,
                 sortOrder
@@ -306,7 +307,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 visualTreeAsset = doc.visualTreeAsset != null ? AssetDatabase.GetAssetPath(doc.visualTreeAsset) : null,
                 panelSettings = doc.panelSettings != null ? AssetDatabase.GetAssetPath(doc.panelSettings) : null,
                 sortingOrder = doc.sortingOrder
@@ -619,7 +621,8 @@ namespace UnitySkills
             var result = docs.Select(doc => new
             {
                 name = doc.gameObject.name,
-                instanceId = doc.gameObject.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(doc.gameObject),
+                instanceId = UnityObjectIdUtility.GetObjectId(doc.gameObject),
                 visualTreeAsset = doc.visualTreeAsset != null ? AssetDatabase.GetAssetPath(doc.visualTreeAsset) : null,
                 panelSettings = doc.panelSettings != null ? AssetDatabase.GetAssetPath(doc.panelSettings) : null,
                 sortingOrder = doc.sortingOrder,
@@ -1697,7 +1700,8 @@ public class {className} : MonoBehaviour
             return new
             {
                 gameObject = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 hierarchy
             };
         }

--- a/SkillsForUnity/Editor/Skills/UnityObjectIdUtility.cs
+++ b/SkillsForUnity/Editor/Skills/UnityObjectIdUtility.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnitySkills
+{
+    internal static class UnityObjectIdUtility
+    {
+        public static string GetEntityId(UnityEngine.Object obj)
+        {
+            if (obj == null)
+                return null;
+
+#if UNITY_6000_4_OR_NEWER
+            return EntityId.ToULong(obj.GetEntityId()).ToString(CultureInfo.InvariantCulture);
+#else
+            return obj.GetInstanceID().ToString(CultureInfo.InvariantCulture);
+#endif
+        }
+
+        public static int GetLegacyInstanceId(UnityEngine.Object obj)
+        {
+            if (obj == null)
+                return 0;
+
+#if UNITY_6000_4_OR_NEWER
+            return 0;
+#else
+            return obj.GetInstanceID();
+#endif
+        }
+
+        public static int GetObjectId(UnityEngine.Object obj)
+        {
+            return GetLegacyInstanceId(obj);
+        }
+
+        public static bool MatchesEntityId(UnityEngine.Object obj, string entityId)
+        {
+            return obj != null &&
+                !string.IsNullOrWhiteSpace(entityId) &&
+                string.Equals(GetEntityId(obj), entityId.Trim(), StringComparison.Ordinal);
+        }
+
+        public static bool MatchesObjectId(UnityEngine.Object obj, int objectId)
+        {
+            return objectId != 0 && GetLegacyInstanceId(obj) == objectId;
+        }
+
+        public static UnityEngine.Object EntityIdToObject(string entityId)
+        {
+            if (string.IsNullOrWhiteSpace(entityId))
+                return null;
+
+            var trimmed = entityId.Trim();
+
+#if UNITY_6000_4_OR_NEWER
+            if (!ulong.TryParse(trimmed, NumberStyles.None, CultureInfo.InvariantCulture, out var rawId))
+                return null;
+
+            try
+            {
+                return EditorUtility.EntityIdToObject(EntityId.FromULong(rawId));
+            }
+            catch
+            {
+                return null;
+            }
+#else
+            if (!int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var instanceId))
+                return null;
+
+            return EditorUtility.InstanceIDToObject(instanceId);
+#endif
+        }
+
+        public static UnityEngine.Object ObjectIdToObject(int objectId)
+        {
+            if (objectId == 0)
+                return null;
+
+#if UNITY_6000_4_OR_NEWER
+            return null;
+#else
+            return EditorUtility.InstanceIDToObject(objectId);
+#endif
+        }
+
+        public static bool HasMissingObjectReference(SerializedProperty property)
+        {
+            if (property == null ||
+                property.propertyType != SerializedPropertyType.ObjectReference ||
+                property.objectReferenceValue != null)
+                return false;
+
+#if UNITY_6000_4_OR_NEWER
+            return property.objectReferenceEntityIdValue.IsValid();
+#else
+            return property.objectReferenceInstanceIDValue != 0;
+#endif
+        }
+
+        public static int[] GetSelectionObjectIds()
+        {
+#if UNITY_6000_4_OR_NEWER
+            return Array.Empty<int>();
+#else
+            return Selection.instanceIDs ?? Array.Empty<int>();
+#endif
+        }
+
+        public static string[] GetSelectionEntityIds()
+        {
+            return Selection.objects?
+                .Where(obj => obj != null)
+                .Select(GetEntityId)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct()
+                .ToArray() ?? Array.Empty<string>();
+        }
+
+        public static void SetSelectionObjectIds(IEnumerable<int> objectIds)
+        {
+            var ids = objectIds?
+                .Where(id => id != 0)
+                .Distinct()
+                .ToArray() ?? Array.Empty<int>();
+
+#if UNITY_6000_4_OR_NEWER
+            Selection.objects = ids
+                .Select(ObjectIdToObject)
+                .Where(obj => obj != null)
+                .ToArray();
+#else
+            Selection.instanceIDs = ids;
+#endif
+        }
+
+        public static void SetSelectionEntityIds(IEnumerable<string> entityIds)
+        {
+            Selection.objects = entityIds?
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct()
+                .Select(EntityIdToObject)
+                .Where(obj => obj != null)
+                .ToArray() ?? Array.Empty<UnityEngine.Object>();
+        }
+    }
+}

--- a/SkillsForUnity/Editor/Skills/UnityObjectIdUtility.cs.meta
+++ b/SkillsForUnity/Editor/Skills/UnityObjectIdUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aaa226257ee73024bacaa7b707485fd2

--- a/SkillsForUnity/Editor/Skills/ValidationSkills.cs
+++ b/SkillsForUnity/Editor/Skills/ValidationSkills.cs
@@ -451,8 +451,7 @@ namespace UnitySkills
                     var prop = so.GetIterator();
                     while (prop.NextVisible(true))
                     {
-                        if (prop.propertyType == SerializedPropertyType.ObjectReference &&
-                            prop.objectReferenceValue == null && prop.objectReferenceInstanceIDValue != 0)
+                        if (UnityObjectIdUtility.HasMissingObjectReference(prop))
                         {
                             results.Add(new { gameObject = go.name, path = GameObjectFinder.GetPath(go),
                                 component = comp.GetType().Name, property = prop.propertyPath });

--- a/SkillsForUnity/Editor/Skills/VolumeSkills.cs
+++ b/SkillsForUnity/Editor/Skills/VolumeSkills.cs
@@ -104,7 +104,8 @@ namespace UnitySkills
                 success = true,
                 name,
                 path = resolvedPath,
-                instanceId = profile.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(profile),
+                instanceId = UnityObjectIdUtility.GetObjectId(profile),
                 componentCount = profile.components.Count
             };
         }
@@ -157,7 +158,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 path = GameObjectFinder.GetPath(go),
                 isGlobal,
                 priority = volume.priority,

--- a/SkillsForUnity/Editor/Skills/WorkflowSkills.cs
+++ b/SkillsForUnity/Editor/Skills/WorkflowSkills.cs
@@ -19,6 +19,7 @@ namespace UnitySkills
 
         private class BookmarkData
         {
+            public string[] selectedEntityIds;
             public int[] selectedInstanceIds;
             public Vector3? sceneViewPosition;
             public Quaternion? sceneViewRotation;
@@ -39,7 +40,8 @@ namespace UnitySkills
 
             var bookmark = new BookmarkData
             {
-                selectedInstanceIds = Selection.instanceIDs ?? Array.Empty<int>(),
+                selectedEntityIds = UnityObjectIdUtility.GetSelectionEntityIds(),
+                selectedInstanceIds = UnityObjectIdUtility.GetSelectionObjectIds(),
                 note = note,
                 createdAt = System.DateTime.Now
             };
@@ -59,7 +61,7 @@ namespace UnitySkills
             {
                 success = true,
                 bookmark = bookmarkName,
-                selectedCount = bookmark.selectedInstanceIds.Length,
+                selectedCount = (bookmark.selectedEntityIds ?? Array.Empty<string>()).Length,
                 hasSceneView = sceneView != null,
                 note
             };
@@ -76,11 +78,21 @@ namespace UnitySkills
             if (!_bookmarks.TryGetValue(bookmarkName, out var bookmark))
                 return new { success = false, error = $"Bookmark '{bookmarkName}' not found" };
 
-            // Restore selection
-            var validIds = (bookmark.selectedInstanceIds ?? Array.Empty<int>())
-                .Where(id => EditorUtility.InstanceIDToObject(id) != null)
+            // Restore selection. Prefer Unity 6000.5-safe EntityIds; legacy instanceIds are kept for older bookmarks.
+            var validEntityIds = (bookmark.selectedEntityIds ?? Array.Empty<string>())
+                .Where(id => UnityObjectIdUtility.EntityIdToObject(id) != null)
                 .ToArray();
-            Selection.instanceIDs = validIds;
+            if (validEntityIds.Length > 0 || bookmark.selectedEntityIds != null)
+            {
+                UnityObjectIdUtility.SetSelectionEntityIds(validEntityIds);
+            }
+            else
+            {
+                var validIds = (bookmark.selectedInstanceIds ?? Array.Empty<int>())
+                    .Where(id => UnityObjectIdUtility.ObjectIdToObject(id) != null)
+                    .ToArray();
+                UnityObjectIdUtility.SetSelectionObjectIds(validIds);
+            }
 
             // Restore scene view
             if (bookmark.sceneViewPosition.HasValue)
@@ -101,7 +113,9 @@ namespace UnitySkills
             {
                 success = true,
                 bookmark = bookmarkName,
-                restoredSelection = validIds.Length,
+                restoredSelection = validEntityIds.Length > 0 || bookmark.selectedEntityIds != null
+                    ? validEntityIds.Length
+                    : (bookmark.selectedInstanceIds ?? Array.Empty<int>()).Count(id => UnityObjectIdUtility.ObjectIdToObject(id) != null),
                 note = bookmark.note
             };
         }
@@ -117,7 +131,9 @@ namespace UnitySkills
             var list = _bookmarks.Select(kv => new
             {
                 name = kv.Key,
-                selectedCount = (kv.Value.selectedInstanceIds ?? Array.Empty<int>()).Length,
+                selectedCount = (kv.Value.selectedEntityIds ?? Array.Empty<string>()).Length > 0
+                    ? kv.Value.selectedEntityIds.Length
+                    : (kv.Value.selectedInstanceIds ?? Array.Empty<int>()).Length,
                 hasSceneView = kv.Value.sceneViewPosition.HasValue,
                 note = kv.Value.note,
                 createdAt = kv.Value.createdAt.ToString("HH:mm:ss")
@@ -235,19 +251,21 @@ namespace UnitySkills
             Tags = new[] { "snapshot", "undo", "object", "state" },
             Outputs = new[] { "objectName", "type" },
             RequiresInput = new[] { "gameObject" })]
-        public static object WorkflowSnapshotObject(string name = null, int instanceId = 0)
+        public static object WorkflowSnapshotObject(string name = null, int instanceId = 0, string entityId = null)
         {
             if (!WorkflowManager.IsRecording)
                 return new { success = false, error = "No active task. Call workflow_task_start first." };
 
             UnityEngine.Object target = null;
-            if (instanceId != 0)
-                target = EditorUtility.InstanceIDToObject(instanceId);
+            if (!string.IsNullOrWhiteSpace(entityId))
+                target = UnityObjectIdUtility.EntityIdToObject(entityId);
+            else if (instanceId != 0)
+                target = UnityObjectIdUtility.ObjectIdToObject(instanceId);
             else if (!string.IsNullOrEmpty(name))
                 target = GameObjectFinder.Find(name: name);
 
             if (target == null)
-                return new { success = false, error = $"Object not found: {name ?? instanceId.ToString()}" };
+                return new { success = false, error = $"Object not found: {entityId ?? name ?? instanceId.ToString()}" };
 
             WorkflowManager.SnapshotObject(target);
             return new { success = true, objectName = target.name, type = target.GetType().Name };
@@ -340,19 +358,21 @@ namespace UnitySkills
             Tags = new[] { "snapshot", "undo", "created", "tracking" },
             Outputs = new[] { "objectName", "type" },
             RequiresInput = new[] { "gameObject" })]
-        public static object WorkflowSnapshotCreated(string name = null, int instanceId = 0)
+        public static object WorkflowSnapshotCreated(string name = null, int instanceId = 0, string entityId = null)
         {
             if (!WorkflowManager.IsRecording)
                 return new { success = false, error = "No active task. Call workflow_task_start first." };
 
             UnityEngine.Object target = null;
-            if (instanceId != 0)
-                target = EditorUtility.InstanceIDToObject(instanceId);
+            if (!string.IsNullOrWhiteSpace(entityId))
+                target = UnityObjectIdUtility.EntityIdToObject(entityId);
+            else if (instanceId != 0)
+                target = UnityObjectIdUtility.ObjectIdToObject(instanceId);
             else if (!string.IsNullOrEmpty(name))
                 target = GameObjectFinder.Find(name: name);
 
             if (target == null)
-                return new { success = false, error = $"Object not found: {name ?? instanceId.ToString()}" };
+                return new { success = false, error = $"Object not found: {entityId ?? name ?? instanceId.ToString()}" };
 
             if (target is Component comp)
                 WorkflowManager.SnapshotCreatedComponent(comp);

--- a/SkillsForUnity/Editor/Skills/XRReflectionHelper.cs
+++ b/SkillsForUnity/Editor/Skills/XRReflectionHelper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UnitySkills.Internal;
 
 namespace UnitySkills
 {
@@ -456,12 +457,7 @@ namespace UnitySkills
             var type = ResolveXRType(typeName);
             if (type == null) return Array.Empty<Component>();
 
-#if UNITY_6000_0_OR_NEWER
-            return UnityEngine.Object.FindObjectsByType(type, FindObjectsInactive.Include, FindObjectsSortMode.None)
-                .OfType<Component>().ToArray();
-#else
-            return UnityEngine.Object.FindObjectsOfType(type).OfType<Component>().ToArray();
-#endif
+            return FindHelper.FindAll(type, includeInactive: true).OfType<Component>().ToArray();
         }
 
         /// <summary>
@@ -484,7 +480,8 @@ namespace UnitySkills
 
             info["type"] = type.Name;
             info["gameObject"] = comp.gameObject.name;
-            info["instanceId"] = comp.gameObject.GetInstanceID();
+            info["entityId"] = UnityObjectIdUtility.GetEntityId(comp.gameObject);
+            info["instanceId"] = UnityObjectIdUtility.GetObjectId(comp.gameObject);
             info["enabled"] = comp is Behaviour b ? b.enabled : true;
 
             // Read common XR properties (verified from XRI source code)

--- a/SkillsForUnity/Editor/Skills/XRSkills.cs
+++ b/SkillsForUnity/Editor/Skills/XRSkills.cs
@@ -160,11 +160,13 @@ namespace UnitySkills
                 // Add detailed component listing
                 info["interactorDetails"] = interactors.Select(c => new {
                     name = c.gameObject.name, type = c.GetType().Name,
-                    instanceId = c.gameObject.GetInstanceID()
+                    entityId = UnityObjectIdUtility.GetEntityId(c.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(c.gameObject)
                 }).ToArray();
                 info["interactableDetails"] = interactables.Select(c => new {
                     name = c.gameObject.name, type = c.GetType().Name,
-                    instanceId = c.gameObject.GetInstanceID()
+                    entityId = UnityObjectIdUtility.GetEntityId(c.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(c.gameObject)
                 }).ToArray();
             }
 
@@ -254,7 +256,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = root.name,
-                instanceId = root.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(root),
+                instanceId = UnityObjectIdUtility.GetObjectId(root),
                 xriVersion = XRReflectionHelper.XRIMajorVersion,
                 hierarchy = new
                 {
@@ -292,7 +295,8 @@ namespace UnitySkills
                     success = true,
                     alreadyExists = true,
                     name = existing.gameObject.name,
-                    instanceId = existing.gameObject.GetInstanceID()
+                    entityId = UnityObjectIdUtility.GetEntityId(existing.gameObject),
+                    instanceId = UnityObjectIdUtility.GetObjectId(existing.gameObject)
                 };
 
             var go = new GameObject(name ?? "XR Interaction Manager");
@@ -306,7 +310,8 @@ namespace UnitySkills
                 success = true,
                 alreadyExists = false,
                 name = go.name,
-                instanceId = go.GetInstanceID()
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go)
             };
 #endif
         }
@@ -370,7 +375,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = esGo.name,
-                instanceId = esGo.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(esGo),
+                instanceId = UnityObjectIdUtility.GetObjectId(esGo),
                 created,
                 removedStandaloneInputModule = removedStandalone,
                 addedXRUIInputModule = addedXRInput
@@ -422,7 +428,8 @@ namespace UnitySkills
                         {
                             ["type"] = comp.GetType().Name,
                             ["gameObject"] = comp.gameObject.name,
-                            ["instanceId"] = comp.gameObject.GetInstanceID(),
+                            ["entityId"] = UnityObjectIdUtility.GetEntityId(comp.gameObject),
+                            ["instanceId"] = UnityObjectIdUtility.GetObjectId(comp.gameObject),
                             ["path"] = GameObjectFinder.GetPath(comp.gameObject),
                             ["enabled"] = comp is Behaviour b ? b.enabled : true
                         };
@@ -515,7 +522,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 interactorType = comp.GetType().Name,
                 maxRaycastDistance = maxDistance,
                 lineType,
@@ -564,7 +572,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 interactorType = comp.GetType().Name,
                 triggerRadius = radius
             };
@@ -612,7 +621,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 interactorType = comp.GetType().Name,
                 showHoverMesh,
                 recycleDelay
@@ -643,7 +653,8 @@ namespace UnitySkills
                     {
                         ["type"] = comp.GetType().Name,
                         ["gameObject"] = comp.gameObject.name,
-                        ["instanceId"] = comp.gameObject.GetInstanceID(),
+                        ["entityId"] = UnityObjectIdUtility.GetEntityId(comp.gameObject),
+                        ["instanceId"] = UnityObjectIdUtility.GetObjectId(comp.gameObject),
                         ["path"] = GameObjectFinder.GetPath(comp.gameObject),
                         ["enabled"] = comp is Behaviour b ? b.enabled : true
                     };
@@ -748,7 +759,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 movementType,
                 throwOnDetach,
                 smoothPosition,
@@ -790,7 +802,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 interactableType = comp.GetType().Name,
                 note = "Use xr_add_interaction_event to wire up hover/select callbacks."
             };
@@ -856,7 +869,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 interactableType = comp.GetType().Name,
                 changedProperties = changed,
                 selectModeOptions = XRReflectionHelper.GetEnumValues(comp, "selectMode"),
@@ -888,7 +902,8 @@ namespace UnitySkills
                     {
                         ["type"] = comp.GetType().Name,
                         ["gameObject"] = comp.gameObject.name,
-                        ["instanceId"] = comp.gameObject.GetInstanceID(),
+                        ["entityId"] = UnityObjectIdUtility.GetEntityId(comp.gameObject),
+                        ["instanceId"] = UnityObjectIdUtility.GetObjectId(comp.gameObject),
                         ["path"] = GameObjectFinder.GetPath(comp.gameObject),
                         ["enabled"] = comp is Behaviour b ? b.enabled : true,
                         ["isSelected"] = (bool)(XRReflectionHelper.GetProperty(comp, "isSelected") ?? false),
@@ -912,7 +927,8 @@ namespace UnitySkills
                     {
                         ["type"] = comp.GetType().Name,
                         ["gameObject"] = comp.gameObject.name,
-                        ["instanceId"] = comp.gameObject.GetInstanceID(),
+                        ["entityId"] = UnityObjectIdUtility.GetEntityId(comp.gameObject),
+                        ["instanceId"] = UnityObjectIdUtility.GetObjectId(comp.gameObject),
                         ["path"] = GameObjectFinder.GetPath(comp.gameObject),
                         ["enabled"] = comp is Behaviour b2 ? b2.enabled : true
                     });
@@ -972,7 +988,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 providerType = comp.GetType().Name,
                 note = "Now create teleport targets via xr_add_teleport_area or xr_add_teleport_anchor."
             };
@@ -1021,7 +1038,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 teleportType = "TeleportationArea",
                 matchOrientation,
                 matchOrientationOptions = XRReflectionHelper.GetEnumValues(comp, "matchOrientation")
@@ -1091,7 +1109,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 teleportType = "TeleportationAnchor",
                 position = new { x, y, z },
                 rotationY = rotY,
@@ -1150,7 +1169,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 providerType = comp.GetType().Name,
                 moveSpeed,
                 enableStrafe,
@@ -1218,7 +1238,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 providerType = comp.GetType().Name,
                 turnType,
                 turnAmount = isSnap ? turnAmount : 0f,
@@ -1283,7 +1304,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 removedStandardRaycaster = removedStandard,
                 addedTrackedDeviceRaycaster = addedTracked,
                 renderMode = "WorldSpace",
@@ -1342,7 +1364,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 interactorType = comp.GetType().Name,
                 changedProperties = changed,
                 selectIntensity,
@@ -1442,7 +1465,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 eventType,
                 targetObject = targetName,
                 targetMethod,
@@ -1515,7 +1539,8 @@ namespace UnitySkills
             {
                 success = true,
                 name = go.name,
-                instanceId = go.GetInstanceID(),
+                entityId = UnityObjectIdUtility.GetEntityId(go),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 componentType = comp.GetType().Name,
                 layers,
                 isInteractor

--- a/SkillsForUnity/Editor/UI/Controllers/AIConfigTabController.cs
+++ b/SkillsForUnity/Editor/UI/Controllers/AIConfigTabController.cs
@@ -145,7 +145,7 @@ namespace UnitySkills
                 // Use backgroundImage instead of Image.image — more reliable in
                 // Editor windows under UI Toolkit 2022.3+. Also lets USS tint.
                 icon.style.backgroundImage = new StyleBackground(tex);
-                icon.style.unityBackgroundScaleMode = ScaleMode.ScaleToFit;
+                icon.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
             }
             head.Add(icon);
 

--- a/SkillsForUnity/Editor/UI/Controllers/TopbarController.cs
+++ b/SkillsForUnity/Editor/UI/Controllers/TopbarController.cs
@@ -138,7 +138,7 @@ namespace UnitySkills
 
             _settingsBtn.text = "";
             _settingsBtn.style.backgroundImage = new StyleBackground((Texture2D)icon);
-            _settingsBtn.style.unityBackgroundScaleMode = ScaleMode.ScaleToFit;
+            _settingsBtn.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
         }
 
         private void BuildPermBadgeContent()

--- a/SkillsForUnity/Tests/Editor/Core/BatchGovernanceTests.cs
+++ b/SkillsForUnity/Tests/Editor/Core/BatchGovernanceTests.cs
@@ -199,7 +199,7 @@ namespace UnitySkills.Tests.Core
             {
                 targetName = go.name,
                 targetPath = GameObjectFinder.GetCachedPath(go),
-                instanceId = go.GetInstanceID(),
+                instanceId = UnityObjectIdUtility.GetObjectId(go),
                 action = "set_property",
                 status = "failed",
                 before = "1",

--- a/SkillsForUnity/package.json
+++ b/SkillsForUnity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.besty.unity-skills",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "displayName": "UnitySkills",
   "description": "AI automation skills specifically designed for Unity",
   "unity": "2022.3",

--- a/SkillsForUnity/unity-skills~/scripts/unity_skills.py
+++ b/SkillsForUnity/unity-skills~/scripts/unity_skills.py
@@ -22,7 +22,7 @@ import threading
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 UNITY_URL = "http://localhost:8090"
 DEFAULT_PORT = 8090

--- a/agent.md
+++ b/agent.md
@@ -7,7 +7,7 @@
 
 | 项目 | 值 |
 |------|----|
-| 版本 | 2.0.3 |
+| 版本 | 2.0.4 |
 | 技术栈 | C# (Unity Editor Plugin) + Python (Client) |
 | Unity | 2022.3+（已验证 Unity 6 / 6000.x） |
 | 协议 | MIT |


### PR DESCRIPTION
- 新增 UnityObjectIdUtility 统一封装 EntityId、legacy InstanceID、Selection 和缺失引用检测

- 批量查询、GameObject 查找、Workflow bookmark/snapshot 等对象定位路径支持 entityId，并保留 instanceId 兼容

- 补齐各技能返回结果中的 entityId 字段，避免 Unity 6000.5 下 instanceId 为 0 后无法稳定复用对象定位

- 同步 Unity 6000.x API 调整和 2.0.4 版本号、README、CHANGELOG