### PR TITLE
feat(router): paginate Summary Mode instead of hard-truncating at 5

### DIFF
--- a/SkillsForUnity/Editor/Skills/SkillRouter.cs
+++ b/SkillsForUnity/Editor/Skills/SkillRouter.cs
@@ -658,87 +658,45 @@ namespace UnitySkills
                     args.Remove("verbose");
                 }
 
-                // Pagination control for Summary Mode
+                // Pagination control for Summary Mode.
+                // Skipped when the skill declares a parameter of the same name: 'limit' belongs to
+                // asset_find/light_find_all/... and must reach the skill as its own argument rather
+                // than being consumed as envelope paging (which would also wrap small results).
                 int? offset = null;
                 int? limit = null;
 
-                if (args.TryGetValue("offset", StringComparison.OrdinalIgnoreCase, out var offsetToken))
+                if (!SkillDeclaresParameter(skill, "offset") &&
+                    args.TryGetValue("offset", StringComparison.OrdinalIgnoreCase, out var offsetToken))
                 {
-                    try
+                    if (!TryReadPagingArg(offsetToken, "offset", minValue: 0, out var offsetValue, out var offsetError))
                     {
-                        offset = offsetToken.ToObject<int>();
-                        if (offset.Value < 0)
-                        {
-                            if (autoStartedWorkflow && WorkflowManager.IsRecording)
-                                WorkflowManager.AbortTask();
-                            else if (WorkflowManager.IsRecording)
-                                WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
-                            if (undoGroup >= 0)
-                                UnityEditor.Undo.RevertAllInCurrentGroup();
-
-                            return SkillErrorResponse.Build(
-                                SkillErrorCode.TypeMismatch,
-                                $"Parameter 'offset' must be a non-negative integer, got: {offset.Value}",
-                                skill: name,
-                                retryStrategy: SkillErrorResponse.RetryFixAndRetry);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        if (autoStartedWorkflow && WorkflowManager.IsRecording)
-                            WorkflowManager.AbortTask();
-                        else if (WorkflowManager.IsRecording)
-                            WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
-                        if (undoGroup >= 0)
-                            UnityEditor.Undo.RevertAllInCurrentGroup();
-
+                        // Nothing was invoked yet; unwind the bookkeeping opened above.
+                        UnwindBeforeInvoke(autoStartedWorkflow, workflowSnapshotCountBefore, undoGroup);
                         return SkillErrorResponse.Build(
                             SkillErrorCode.TypeMismatch,
-                            $"Parameter 'offset' must be an integer, got: {offsetToken.ToString(Formatting.None)}",
+                            offsetError,
                             skill: name,
-                            details: new { typeErrors = new object[] { new { parameter = "offset", expectedType = "integer", error = $"Cannot convert {offsetToken.Type} to Int32" } } },
+                            details: new { typeErrors = new object[] { new { parameter = "offset", expectedType = "integer", error = offsetError } } },
                             retryStrategy: SkillErrorResponse.RetryFixAndRetry);
                     }
+                    offset = offsetValue;
                     args.Remove("offset");
                 }
 
-                if (args.TryGetValue("limit", StringComparison.OrdinalIgnoreCase, out var limitToken))
+                if (!SkillDeclaresParameter(skill, "limit") &&
+                    args.TryGetValue("limit", StringComparison.OrdinalIgnoreCase, out var limitToken))
                 {
-                    try
+                    if (!TryReadPagingArg(limitToken, "limit", minValue: 1, out var limitValue, out var limitError))
                     {
-                        limit = limitToken.ToObject<int>();
-                        if (limit.Value <= 0)
-                        {
-                            if (autoStartedWorkflow && WorkflowManager.IsRecording)
-                                WorkflowManager.AbortTask();
-                            else if (WorkflowManager.IsRecording)
-                                WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
-                            if (undoGroup >= 0)
-                                UnityEditor.Undo.RevertAllInCurrentGroup();
-
-                            return SkillErrorResponse.Build(
-                                SkillErrorCode.TypeMismatch,
-                                $"Parameter 'limit' must be a positive integer, got: {limit.Value}",
-                                skill: name,
-                                retryStrategy: SkillErrorResponse.RetryFixAndRetry);
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        if (autoStartedWorkflow && WorkflowManager.IsRecording)
-                            WorkflowManager.AbortTask();
-                        else if (WorkflowManager.IsRecording)
-                            WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
-                        if (undoGroup >= 0)
-                            UnityEditor.Undo.RevertAllInCurrentGroup();
-
+                        UnwindBeforeInvoke(autoStartedWorkflow, workflowSnapshotCountBefore, undoGroup);
                         return SkillErrorResponse.Build(
                             SkillErrorCode.TypeMismatch,
-                            $"Parameter 'limit' must be an integer, got: {limitToken.ToString(Formatting.None)}",
+                            limitError,
                             skill: name,
-                            details: new { typeErrors = new object[] { new { parameter = "limit", expectedType = "integer", error = $"Cannot convert {limitToken.Type} to Int32" } } },
+                            details: new { typeErrors = new object[] { new { parameter = "limit", expectedType = "integer", error = limitError } } },
                             retryStrategy: SkillErrorResponse.RetryFixAndRetry);
                     }
+                    limit = limitValue;
                     args.Remove("limit");
                 }
 
@@ -1478,6 +1436,66 @@ namespace UnitySkills
                 .Concat(new[] { EntityIdParameterName })
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
+        }
+
+        /// <summary>
+        /// True when the skill itself declares a parameter with this name. Such names must reach
+        /// the skill as its own argument and must not be consumed as envelope-level paging.
+        /// </summary>
+        private static bool SkillDeclaresParameter(SkillInfo skill, string parameterName) =>
+            skill != null && ContainsParameter(skill.ParameterNames, parameterName);
+
+        /// <summary>
+        /// Reads an envelope paging argument ('offset'/'limit') as an integer >= minValue.
+        /// Accepts JSON numbers and their string forms ("10") so query-string callers work too.
+        /// </summary>
+        private static bool TryReadPagingArg(JToken token, string parameterName, int minValue, out int value, out string error)
+        {
+            value = 0;
+            error = null;
+
+            int parsed;
+            try
+            {
+                parsed = token.ToObject<int>();
+            }
+            catch (Exception)
+            {
+                var raw = token.Type == JTokenType.String ? token.Value<string>()?.Trim() : null;
+                if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out parsed))
+                {
+                    error = $"Parameter '{parameterName}' must be an integer, got: {token.ToString(Formatting.None)}";
+                    return false;
+                }
+            }
+
+            if (parsed < minValue)
+            {
+                error = minValue <= 0
+                    ? $"Parameter '{parameterName}' must be a non-negative integer, got: {parsed}"
+                    : $"Parameter '{parameterName}' must be a positive integer, got: {parsed}";
+                return false;
+            }
+
+            value = parsed;
+            return true;
+        }
+
+        /// <summary>
+        /// Unwinds the workflow/undo bookkeeping opened before <c>Method.Invoke</c> when an
+        /// envelope-level argument turns out to be invalid and nothing was executed yet.
+        /// Mirrors the cleanup performed by the catch handlers in Execute.
+        /// </summary>
+        private static void UnwindBeforeInvoke(bool autoStartedWorkflow, int workflowSnapshotCountBefore, int undoGroup)
+        {
+            if (autoStartedWorkflow && WorkflowManager.IsRecording)
+                WorkflowManager.AbortTask();
+            else if (WorkflowManager.IsRecording)
+                WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
+
+            if (undoGroup >= 0)
+                UnityEditor.Undo.RevertAllInCurrentGroup();
         }
 
         private static object[] BuildParameterSchema(SkillInfo skill)

--- a/SkillsForUnity/Editor/Skills/SkillRouter.cs
+++ b/SkillsForUnity/Editor/Skills/SkillRouter.cs
@@ -120,6 +120,8 @@ namespace UnitySkills
         private static readonly HashSet<string> _reservedBodyParameters = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "verbose",
+            "offset",
+            "limit",
             "_confirm"
         };
 
@@ -656,6 +658,90 @@ namespace UnitySkills
                     args.Remove("verbose");
                 }
 
+                // Pagination control for Summary Mode
+                int? offset = null;
+                int? limit = null;
+
+                if (args.TryGetValue("offset", StringComparison.OrdinalIgnoreCase, out var offsetToken))
+                {
+                    try
+                    {
+                        offset = offsetToken.ToObject<int>();
+                        if (offset.Value < 0)
+                        {
+                            if (autoStartedWorkflow && WorkflowManager.IsRecording)
+                                WorkflowManager.AbortTask();
+                            else if (WorkflowManager.IsRecording)
+                                WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
+                            if (undoGroup >= 0)
+                                UnityEditor.Undo.RevertAllInCurrentGroup();
+
+                            return SkillErrorResponse.Build(
+                                SkillErrorCode.TypeMismatch,
+                                $"Parameter 'offset' must be a non-negative integer, got: {offset.Value}",
+                                skill: name,
+                                retryStrategy: SkillErrorResponse.RetryFixAndRetry);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        if (autoStartedWorkflow && WorkflowManager.IsRecording)
+                            WorkflowManager.AbortTask();
+                        else if (WorkflowManager.IsRecording)
+                            WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
+                        if (undoGroup >= 0)
+                            UnityEditor.Undo.RevertAllInCurrentGroup();
+
+                        return SkillErrorResponse.Build(
+                            SkillErrorCode.TypeMismatch,
+                            $"Parameter 'offset' must be an integer, got: {offsetToken.ToString(Formatting.None)}",
+                            skill: name,
+                            details: new { typeErrors = new object[] { new { parameter = "offset", expectedType = "integer", error = $"Cannot convert {offsetToken.Type} to Int32" } } },
+                            retryStrategy: SkillErrorResponse.RetryFixAndRetry);
+                    }
+                    args.Remove("offset");
+                }
+
+                if (args.TryGetValue("limit", StringComparison.OrdinalIgnoreCase, out var limitToken))
+                {
+                    try
+                    {
+                        limit = limitToken.ToObject<int>();
+                        if (limit.Value <= 0)
+                        {
+                            if (autoStartedWorkflow && WorkflowManager.IsRecording)
+                                WorkflowManager.AbortTask();
+                            else if (WorkflowManager.IsRecording)
+                                WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
+                            if (undoGroup >= 0)
+                                UnityEditor.Undo.RevertAllInCurrentGroup();
+
+                            return SkillErrorResponse.Build(
+                                SkillErrorCode.TypeMismatch,
+                                $"Parameter 'limit' must be a positive integer, got: {limit.Value}",
+                                skill: name,
+                                retryStrategy: SkillErrorResponse.RetryFixAndRetry);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        if (autoStartedWorkflow && WorkflowManager.IsRecording)
+                            WorkflowManager.AbortTask();
+                        else if (WorkflowManager.IsRecording)
+                            WorkflowManager.TruncateCurrentTask(workflowSnapshotCountBefore);
+                        if (undoGroup >= 0)
+                            UnityEditor.Undo.RevertAllInCurrentGroup();
+
+                        return SkillErrorResponse.Build(
+                            SkillErrorCode.TypeMismatch,
+                            $"Parameter 'limit' must be an integer, got: {limitToken.ToString(Formatting.None)}",
+                            skill: name,
+                            details: new { typeErrors = new object[] { new { parameter = "limit", expectedType = "integer", error = $"Cannot convert {limitToken.Type} to Int32" } } },
+                            retryStrategy: SkillErrorResponse.RetryFixAndRetry);
+                    }
+                    args.Remove("limit");
+                }
+
                 var result = skill.Method.Invoke(null, invoke);
 
                 if (!skill.ReadOnly)
@@ -730,26 +816,63 @@ namespace UnitySkills
 
                 if (!verbose && result != null)
                 {
-                    // "Summary Mode" Logic
+                    // "Summary Mode" Logic with Pagination
                     // 1. Convert result to JToken to inspect it
                     var jsonResult = JToken.FromObject(result);
 
-                    // 2. Check if it's a large Array (> 10 items)
-                    if (jsonResult is JArray arr && arr.Count > 10)
+                    // 2. Check if it's a large Array (> 10 items, or any array with explicit offset/limit)
+                    if (jsonResult is JArray arr && (arr.Count > 10 || offset.HasValue || limit.HasValue))
                     {
-                        var truncatedItems = new JArray();
-                        for (int i = 0; i < 5; i++) truncatedItems.Add(arr[i]);
+                        int startIndex = offset ?? 0;
+                        int pageSize = limit ?? 5;
 
-                        // Return a wrapper object instead of the list
-                        // This keeps 'items' clean (same type) while providing meta info
+                        // Clamp to valid range
+                        if (startIndex >= arr.Count)
+                        {
+                            // offset beyond array bounds — return empty page
+                            var emptyWrapper = new JObject
+                            {
+                                ["isTruncated"] = true,
+                                ["totalCount"] = arr.Count,
+                                ["offset"] = startIndex,
+                                ["limit"] = pageSize,
+                                ["showing"] = 0,
+                                ["items"] = new JArray(),
+                                ["hint"] = $"Offset {startIndex} is beyond array bounds (totalCount: {arr.Count}). To see items, pass a lower 'offset' value."
+                            };
+                            return SerializeSuccessResponse(emptyWrapper, sceneDiff, workflowEndMs);
+                        }
+
+                        int endIndex = Math.Min(startIndex + pageSize, arr.Count);
+                        int actualCount = endIndex - startIndex;
+
+                        var paginatedItems = new JArray();
+                        for (int i = startIndex; i < endIndex; i++)
+                            paginatedItems.Add(arr[i]);
+
+                        bool hasMore = endIndex < arr.Count;
+                        int? nextOffset = hasMore ? (int?)endIndex : null;
+
+                        // Return a wrapper object with pagination metadata
                         var wrapper = new JObject
                         {
                             ["isTruncated"] = true,
                             ["totalCount"] = arr.Count,
-                            ["showing"] = 5,
-                            ["items"] = truncatedItems,
-                            ["hint"] = "Result is truncated. To see all items, pass 'verbose=true' parameter."
+                            ["offset"] = startIndex,
+                            ["limit"] = pageSize,
+                            ["showing"] = actualCount,
+                            ["items"] = paginatedItems
                         };
+
+                        if (hasMore)
+                        {
+                            wrapper["nextOffset"] = nextOffset;
+                            wrapper["hint"] = $"Showing items {startIndex}-{endIndex - 1} of {arr.Count}. To see more, pass 'offset={nextOffset}' (or 'verbose=true' for all items).";
+                        }
+                        else
+                        {
+                            wrapper["hint"] = $"Showing items {startIndex}-{endIndex - 1} of {arr.Count} (last page).";
+                        }
 
                         return SerializeSuccessResponse(wrapper, sceneDiff, workflowEndMs);
                     }

--- a/SkillsForUnity/Editor/Skills/SkillRouter.cs
+++ b/SkillsForUnity/Editor/Skills/SkillRouter.cs
@@ -122,6 +122,8 @@ namespace UnitySkills
             "verbose",
             "offset",
             "limit",
+            "pageOffset",
+            "pageLimit",
             "_confirm"
         };
 
@@ -665,7 +667,31 @@ namespace UnitySkills
                 int? offset = null;
                 int? limit = null;
 
-                if (!SkillDeclaresParameter(skill, "offset") &&
+                if (args.TryGetValue("pageOffset", StringComparison.OrdinalIgnoreCase, out var pageOffsetToken))
+                {
+                    if (!TryReadPagingArg(pageOffsetToken, "pageOffset", 0, out var value, out var error))
+                    {
+                        UnwindBeforeInvoke(autoStartedWorkflow, workflowSnapshotCountBefore, undoGroup);
+                        return SkillErrorResponse.Build(SkillErrorCode.TypeMismatch, error, skill: name,
+                            retryStrategy: SkillErrorResponse.RetryFixAndRetry);
+                    }
+                    offset = value;
+                    args.Remove("pageOffset");
+                }
+
+                if (args.TryGetValue("pageLimit", StringComparison.OrdinalIgnoreCase, out var pageLimitToken))
+                {
+                    if (!TryReadPagingArg(pageLimitToken, "pageLimit", 1, out var value, out var error))
+                    {
+                        UnwindBeforeInvoke(autoStartedWorkflow, workflowSnapshotCountBefore, undoGroup);
+                        return SkillErrorResponse.Build(SkillErrorCode.TypeMismatch, error, skill: name,
+                            retryStrategy: SkillErrorResponse.RetryFixAndRetry);
+                    }
+                    limit = value;
+                    args.Remove("pageLimit");
+                }
+
+                if (!offset.HasValue && !SkillDeclaresParameter(skill, "offset") &&
                     args.TryGetValue("offset", StringComparison.OrdinalIgnoreCase, out var offsetToken))
                 {
                     if (!TryReadPagingArg(offsetToken, "offset", minValue: 0, out var offsetValue, out var offsetError))
@@ -683,7 +709,7 @@ namespace UnitySkills
                     args.Remove("offset");
                 }
 
-                if (!SkillDeclaresParameter(skill, "limit") &&
+                if (!limit.HasValue && !SkillDeclaresParameter(skill, "limit") &&
                     args.TryGetValue("limit", StringComparison.OrdinalIgnoreCase, out var limitToken))
                 {
                     if (!TryReadPagingArg(limitToken, "limit", minValue: 1, out var limitValue, out var limitError))
@@ -778,8 +804,8 @@ namespace UnitySkills
                     // 1. Convert result to JToken to inspect it
                     var jsonResult = JToken.FromObject(result);
 
-                    // 2. Check if it's a large Array (> 10 items, or any array with explicit offset/limit)
-                    if (jsonResult is JArray arr && (arr.Count > 10 || offset.HasValue || limit.HasValue))
+                    var arr = FindPageArray(jsonResult, out var arrayProperty);
+                    if (arr != null && (arr.Count > 10 || offset.HasValue || limit.HasValue))
                     {
                         int startIndex = offset ?? 0;
                         int pageSize = limit ?? 5;
@@ -798,10 +824,18 @@ namespace UnitySkills
                                 ["items"] = new JArray(),
                                 ["hint"] = $"Offset {startIndex} is beyond array bounds (totalCount: {arr.Count}). To see items, pass a lower 'offset' value."
                             };
+                            if (arrayProperty != null)
+                            {
+                                var preserved = (JObject)jsonResult.DeepClone();
+                                preserved[arrayProperty] = new JArray();
+                                foreach (var property in emptyWrapper.Properties().Where(property => property.Name != "items"))
+                                    preserved[property.Name] = property.Value;
+                                return SerializeSuccessResponse(preserved, sceneDiff, workflowEndMs);
+                            }
                             return SerializeSuccessResponse(emptyWrapper, sceneDiff, workflowEndMs);
                         }
 
-                        int endIndex = Math.Min(startIndex + pageSize, arr.Count);
+                        int endIndex = (int)Math.Min((long)startIndex + pageSize, arr.Count);
                         int actualCount = endIndex - startIndex;
 
                         var paginatedItems = new JArray();
@@ -830,6 +864,15 @@ namespace UnitySkills
                         else
                         {
                             wrapper["hint"] = $"Showing items {startIndex}-{endIndex - 1} of {arr.Count} (last page).";
+                        }
+
+                        if (arrayProperty != null)
+                        {
+                            var preserved = (JObject)jsonResult.DeepClone();
+                            preserved[arrayProperty] = paginatedItems;
+                            foreach (var property in wrapper.Properties().Where(property => property.Name != "items"))
+                                preserved[property.Name] = property.Value;
+                            return SerializeSuccessResponse(preserved, sceneDiff, workflowEndMs);
                         }
 
                         return SerializeSuccessResponse(wrapper, sceneDiff, workflowEndMs);
@@ -1454,20 +1497,14 @@ namespace UnitySkills
             value = 0;
             error = null;
 
-            int parsed;
-            try
+            var raw = token.Type == JTokenType.Integer
+                ? token.ToString(Formatting.None)
+                : token.Type == JTokenType.String ? token.Value<string>()?.Trim() : null;
+            if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture, out var parsed))
             {
-                parsed = token.ToObject<int>();
-            }
-            catch (Exception)
-            {
-                var raw = token.Type == JTokenType.String ? token.Value<string>()?.Trim() : null;
-                if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer,
-                        System.Globalization.CultureInfo.InvariantCulture, out parsed))
-                {
-                    error = $"Parameter '{parameterName}' must be an integer, got: {token.ToString(Formatting.None)}";
-                    return false;
-                }
+                error = $"Parameter '{parameterName}' must be an integer, got: {token.ToString(Formatting.None)}";
+                return false;
             }
 
             if (parsed < minValue)
@@ -1480,6 +1517,25 @@ namespace UnitySkills
 
             value = parsed;
             return true;
+        }
+
+        private static JArray FindPageArray(JToken result, out string propertyName)
+        {
+            propertyName = null;
+            if (result is JArray array)
+                return array;
+            if (!(result is JObject obj))
+                return null;
+
+            foreach (var name in new[] { "items", "assets", "objects", "groups", "entries" })
+            {
+                if (obj[name] is JArray nested)
+                {
+                    propertyName = name;
+                    return nested;
+                }
+            }
+            return null;
         }
 
         /// <summary>

--- a/SkillsForUnity/Editor/Skills/SkillRouter.cs
+++ b/SkillsForUnity/Editor/Skills/SkillRouter.cs
@@ -822,7 +822,7 @@ namespace UnitySkills
                                 ["limit"] = pageSize,
                                 ["showing"] = 0,
                                 ["items"] = new JArray(),
-                                ["hint"] = $"Offset {startIndex} is beyond array bounds (totalCount: {arr.Count}). To see items, pass a lower 'offset' value."
+                                ["hint"] = $"Offset {startIndex} is beyond array bounds (totalCount: {arr.Count}). To see items, pass a lower 'pageOffset' value."
                             };
                             if (arrayProperty != null)
                             {
@@ -859,7 +859,7 @@ namespace UnitySkills
                         if (hasMore)
                         {
                             wrapper["nextOffset"] = nextOffset;
-                            wrapper["hint"] = $"Showing items {startIndex}-{endIndex - 1} of {arr.Count}. To see more, pass 'offset={nextOffset}' (or 'verbose=true' for all items).";
+                            wrapper["hint"] = $"Showing items {startIndex}-{endIndex - 1} of {arr.Count}. To see more, pass 'pageOffset={nextOffset}' (or 'verbose=true' for all items).";
                         }
                         else
                         {

--- a/SkillsForUnity/Tests/Editor/Core/SkillRouterExecuteEndToEndTests.cs
+++ b/SkillsForUnity/Tests/Editor/Core/SkillRouterExecuteEndToEndTests.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using System.IO;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -19,6 +20,7 @@ namespace UnitySkills.Tests.Core
     [TestFixture]
     public class SkillRouterExecuteEndToEndTests
     {
+        private const string PaginationAssetPrefix = "Assets/UnitySkillsPaginationProbe";
         private const string PrefKeyMode = "UnitySkills_OperatingMode";
         private const string PrefKeyPanelApproval = "UnitySkills_PanelApprovalRequired";
 
@@ -58,12 +60,39 @@ namespace UnitySkills.Tests.Core
         [TearDown]
         public void TearDown()
         {
+            for (var i = 0; i < 3; i++)
+                AssetDatabase.DeleteAsset($"{PaginationAssetPrefix}{i}.txt");
             SkillsModeManager.ClearOneShotBypass();
             SkillsModeManager.ResetForTests();
             SkillsModeManager.ExistingInstallOverrideForTests = null;
             SkillsAuditLog.ResetForTests();
             EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
             GameObjectFinder.InvalidateCache();
+        }
+
+        [Test]
+        public void Execute_AssetFind_PagesNestedAssetsAndPreservesMetadata()
+        {
+            SkillsModeManager.CurrentMode = SkillsOperatingMode.Bypass;
+            for (var i = 0; i < 3; i++)
+            {
+                File.WriteAllText($"{PaginationAssetPrefix}{i}.txt", i.ToString());
+                AssetDatabase.ImportAsset($"{PaginationAssetPrefix}{i}.txt");
+            }
+
+            var full = JObject.Parse(SkillRouter.Execute("asset_find",
+                "{\"searchFilter\":\"UnitySkillsPaginationProbe\",\"limit\":10,\"verbose\":false}"));
+            var page = JObject.Parse(SkillRouter.Execute("asset_find",
+                "{\"searchFilter\":\"UnitySkillsPaginationProbe\",\"limit\":10,\"pageOffset\":1,\"pageLimit\":1,\"verbose\":false}"));
+
+            Assert.That(page["status"]?.ToString(), Is.EqualTo("success"));
+            Assert.That(page["result"]?["count"]?.Value<int>(), Is.EqualTo(3));
+            Assert.That(page["result"]?["totalFound"]?.Value<int>(), Is.EqualTo(3));
+            Assert.That(page["result"]?["assets"], Has.Count.EqualTo(1));
+            Assert.That(page["result"]?["assets"]?[0]?["path"]?.ToString(),
+                Is.EqualTo(full["result"]?["assets"]?[1]?["path"]?.ToString()));
+            Assert.That(page["result"]?["offset"]?.Value<int>(), Is.EqualTo(1));
+            Assert.That(page["result"]?["limit"]?.Value<int>(), Is.EqualTo(1));
         }
 
         [Test]

--- a/SkillsForUnity/Tests/Editor/Core/SkillRouterExecuteEndToEndTests.cs
+++ b/SkillsForUnity/Tests/Editor/Core/SkillRouterExecuteEndToEndTests.cs
@@ -93,6 +93,7 @@ namespace UnitySkills.Tests.Core
                 Is.EqualTo(full["result"]?["assets"]?[1]?["path"]?.ToString()));
             Assert.That(page["result"]?["offset"]?.Value<int>(), Is.EqualTo(1));
             Assert.That(page["result"]?["limit"]?.Value<int>(), Is.EqualTo(1));
+            Assert.That(page["result"]?["hint"]?.ToString(), Does.Contain("pageOffset=2"));
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Replaces hard truncation in Summary Mode with unambiguous envelope pagination while preserving skill-owned paging parameters and result metadata.

## Contract

Envelope pagination uses `pageOffset` and `pageLimit`:

```json
{
  "searchFilter": "t:Material",
  "limit": 100,
  "pageOffset": 20,
  "pageLimit": 10,
  "verbose": false
}
```

`limit` above still belongs to `asset_find`; `pageLimit` belongs to the router envelope.

## Behavior

- Supports top-level arrays and nested arrays named `items`, `assets`, `objects`, `groups`, or `entries`.
- Preserves sibling metadata such as `count` and `totalFound`.
- Returns `offset`, `limit`, `showing`, `nextOffset`, and a `pageOffset` continuation hint.
- Rejects fractional and otherwise invalid integer values with `TYPE_MISMATCH`.
- Uses overflow-safe page-bound arithmetic.
- Existing skill-level `offset` and `limit` parameters remain untouched.
- Existing no-argument Summary Mode behavior remains backward compatible.

## Verification

- Unity 6000.3.11f1 focused real `asset_find` E2E: passed.
- Full EditMode: `219/219` passed.
- `git diff --check`: passed.
- PR scope is now only `SkillRouter.cs` and its end-to-end test.