### PR TITLE
fix: preserve Bypass mode after domain reload

### DIFF
--- a/SkillsForUnity/Editor/Skills/SkillsModeManager.cs
+++ b/SkillsForUnity/Editor/Skills/SkillsModeManager.cs
@@ -68,6 +68,7 @@ namespace UnitySkills
     /// NeverInSemi (incl. FullAuto write skills) executes directly; only NeverInSemi
     /// (Delete / MayEnterPlayMode / MayTriggerReload / RiskLevel=high) returns MODE_FORBIDDEN.
     /// </summary>
+    [InitializeOnLoad]
     public static class SkillsModeManager
     {
         public enum AccessResult { Allowed, NeedsGrant, Forbidden }
@@ -82,6 +83,20 @@ namespace UnitySkills
         private const string PrefKeyMigrationDone = "UnitySkills_AllowlistMigratedFromGranted";
         /// <summary>旧 GrantedSkills key（仅用于一次性迁移读取，迁移后不删除以便回滚）。</summary>
         private const string PrefKeyLegacyGranted = "UnitySkills_GrantedSkills";
+
+        // ResetForTests temporarily clears these machine-wide preferences. SessionState survives
+        // a domain reload, allowing the user's settings to be restored if a test run is interrupted.
+        private const string TestRecoveryActiveKey = "UnitySkills.Tests.PreferenceRecovery.Active";
+        private const string TestRecoveryModeExistsKey = "UnitySkills.Tests.PreferenceRecovery.Mode.Exists";
+        private const string TestRecoveryModeValueKey = "UnitySkills.Tests.PreferenceRecovery.Mode.Value";
+        private const string TestRecoveryPanelApprovalExistsKey = "UnitySkills.Tests.PreferenceRecovery.PanelApproval.Exists";
+        private const string TestRecoveryPanelApprovalValueKey = "UnitySkills.Tests.PreferenceRecovery.PanelApproval.Value";
+        private const string TestRecoveryAllowlistExistsKey = "UnitySkills.Tests.PreferenceRecovery.Allowlist.Exists";
+        private const string TestRecoveryAllowlistValueKey = "UnitySkills.Tests.PreferenceRecovery.Allowlist.Value";
+        private const string TestRecoveryMigrationExistsKey = "UnitySkills.Tests.PreferenceRecovery.Migration.Exists";
+        private const string TestRecoveryMigrationValueKey = "UnitySkills.Tests.PreferenceRecovery.Migration.Value";
+        private const string TestRecoveryLegacyGrantedExistsKey = "UnitySkills.Tests.PreferenceRecovery.LegacyGranted.Exists";
+        private const string TestRecoveryLegacyGrantedValueKey = "UnitySkills.Tests.PreferenceRecovery.LegacyGranted.Value";
 
         private const int DefaultGrantTtlSeconds = 300;
         private const int MaxLiveGrants = 256;
@@ -135,6 +150,11 @@ namespace UnitySkills
         private static readonly TimeSpan OneShotLifetime = TimeSpan.FromSeconds(30);
 
         public static event Action OnChanged;
+
+        static SkillsModeManager()
+        {
+            RestorePreferencesAfterTestDomainReload();
+        }
 
         // ===== Properties =====
 
@@ -622,6 +642,7 @@ namespace UnitySkills
         /// <summary>Test-only: clear all state (allowlist, pending, prefs, migration flag) to a clean slate.</summary>
         internal static void ResetForTests()
         {
+            CapturePreferencesForTestRecovery();
             _grants.Clear();
             lock (_allowlistLock)
             {
@@ -635,6 +656,29 @@ namespace UnitySkills
             EditorPrefs.DeleteKey(PrefKeyMigrationDone);
             EditorPrefs.DeleteKey(PrefKeyLegacyGranted);
             RaiseChanged();
+        }
+
+        /// <summary>Test-only: clears recovery data after the fixture restores its original preferences.</summary>
+        internal static void CompleteTestPreferenceRecovery()
+        {
+            ClearTestPreferenceRecovery();
+        }
+
+        /// <summary>Test-only: simulates the recovery performed by the static initializer after a domain reload.</summary>
+        internal static void RestorePreferencesAfterTestDomainReload()
+        {
+            if (!SessionState.GetBool(TestRecoveryActiveKey, false)) return;
+
+            RestoreStringPreference(PrefKeyMode, TestRecoveryModeExistsKey, TestRecoveryModeValueKey);
+            RestoreBoolPreference(PrefKeyPanelApproval, TestRecoveryPanelApprovalExistsKey,
+                TestRecoveryPanelApprovalValueKey);
+            RestoreStringPreference(PrefKeyAllowlist, TestRecoveryAllowlistExistsKey,
+                TestRecoveryAllowlistValueKey);
+            RestoreBoolPreference(PrefKeyMigrationDone, TestRecoveryMigrationExistsKey,
+                TestRecoveryMigrationValueKey);
+            RestoreStringPreference(PrefKeyLegacyGranted, TestRecoveryLegacyGrantedExistsKey,
+                TestRecoveryLegacyGrantedValueKey);
+            ClearTestPreferenceRecovery();
         }
 
         /// <summary>Look up a pending grant entry by token (internal — used by SkillRouter to surface argsSummary).</summary>
@@ -793,6 +837,67 @@ namespace UnitySkills
                 foreach (var b in hash) sb.Append(b.ToString("x2"));
                 return sb.ToString();
             }
+        }
+
+        private static void CapturePreferencesForTestRecovery()
+        {
+            if (SessionState.GetBool(TestRecoveryActiveKey, false)) return;
+
+            StoreStringPreference(PrefKeyMode, TestRecoveryModeExistsKey, TestRecoveryModeValueKey);
+            StoreBoolPreference(PrefKeyPanelApproval, TestRecoveryPanelApprovalExistsKey,
+                TestRecoveryPanelApprovalValueKey);
+            StoreStringPreference(PrefKeyAllowlist, TestRecoveryAllowlistExistsKey,
+                TestRecoveryAllowlistValueKey);
+            StoreBoolPreference(PrefKeyMigrationDone, TestRecoveryMigrationExistsKey,
+                TestRecoveryMigrationValueKey);
+            StoreStringPreference(PrefKeyLegacyGranted, TestRecoveryLegacyGrantedExistsKey,
+                TestRecoveryLegacyGrantedValueKey);
+            SessionState.SetBool(TestRecoveryActiveKey, true);
+        }
+
+        private static void StoreStringPreference(string preferenceKey, string existsKey, string valueKey)
+        {
+            var exists = EditorPrefs.HasKey(preferenceKey);
+            SessionState.SetBool(existsKey, exists);
+            SessionState.SetString(valueKey, exists ? EditorPrefs.GetString(preferenceKey) : string.Empty);
+        }
+
+        private static void StoreBoolPreference(string preferenceKey, string existsKey, string valueKey)
+        {
+            var exists = EditorPrefs.HasKey(preferenceKey);
+            SessionState.SetBool(existsKey, exists);
+            SessionState.SetBool(valueKey, exists && EditorPrefs.GetBool(preferenceKey));
+        }
+
+        private static void RestoreStringPreference(string preferenceKey, string existsKey, string valueKey)
+        {
+            if (SessionState.GetBool(existsKey, false))
+                EditorPrefs.SetString(preferenceKey, SessionState.GetString(valueKey, string.Empty));
+            else
+                EditorPrefs.DeleteKey(preferenceKey);
+        }
+
+        private static void RestoreBoolPreference(string preferenceKey, string existsKey, string valueKey)
+        {
+            if (SessionState.GetBool(existsKey, false))
+                EditorPrefs.SetBool(preferenceKey, SessionState.GetBool(valueKey, false));
+            else
+                EditorPrefs.DeleteKey(preferenceKey);
+        }
+
+        private static void ClearTestPreferenceRecovery()
+        {
+            SessionState.EraseBool(TestRecoveryActiveKey);
+            SessionState.EraseBool(TestRecoveryModeExistsKey);
+            SessionState.EraseString(TestRecoveryModeValueKey);
+            SessionState.EraseBool(TestRecoveryPanelApprovalExistsKey);
+            SessionState.EraseBool(TestRecoveryPanelApprovalValueKey);
+            SessionState.EraseBool(TestRecoveryAllowlistExistsKey);
+            SessionState.EraseString(TestRecoveryAllowlistValueKey);
+            SessionState.EraseBool(TestRecoveryMigrationExistsKey);
+            SessionState.EraseBool(TestRecoveryMigrationValueKey);
+            SessionState.EraseBool(TestRecoveryLegacyGrantedExistsKey);
+            SessionState.EraseString(TestRecoveryLegacyGrantedValueKey);
         }
 
         /// <summary>

--- a/SkillsForUnity/Tests/Editor/Core/SkillRouterExecuteEndToEndTests.cs
+++ b/SkillsForUnity/Tests/Editor/Core/SkillRouterExecuteEndToEndTests.cs
@@ -43,6 +43,7 @@ namespace UnitySkills.Tests.Core
             else EditorPrefs.DeleteKey(PrefKeyMode);
             if (_hadPanelApproval) EditorPrefs.SetBool(PrefKeyPanelApproval, _savedPanelApproval);
             else EditorPrefs.DeleteKey(PrefKeyPanelApproval);
+            SkillsModeManager.CompleteTestPreferenceRecovery();
         }
 
         [SetUp]

--- a/SkillsForUnity/Tests/Editor/Core/SkillsModeManagerOneShotTests.cs
+++ b/SkillsForUnity/Tests/Editor/Core/SkillsModeManagerOneShotTests.cs
@@ -42,6 +42,7 @@ namespace UnitySkills.Tests.Core
             else EditorPrefs.DeleteKey(PrefKeyMode);
             if (_hadPanelApproval) EditorPrefs.SetBool(PrefKeyPanelApproval, _savedPanelApproval);
             else EditorPrefs.DeleteKey(PrefKeyPanelApproval);
+            SkillsModeManager.CompleteTestPreferenceRecovery();
         }
 
         [SetUp]

--- a/SkillsForUnity/Tests/Editor/Core/SkillsModeManagerTests.cs
+++ b/SkillsForUnity/Tests/Editor/Core/SkillsModeManagerTests.cs
@@ -69,6 +69,7 @@ namespace UnitySkills.Tests.Core
             RestoreString(PrefKeyLegacyGranted, _hadLegacyGranted, _savedLegacyGranted);
             SkillsModeManager.ExistingInstallOverrideForTests = null;
             ForceAllowlistReload();
+            SkillsModeManager.CompleteTestPreferenceRecovery();
         }
 
         [SetUp]
@@ -491,6 +492,21 @@ namespace UnitySkills.Tests.Core
             // SetUp left zero UnitySkills_* keys behind.
             Assert.AreEqual(SkillsOperatingMode.Auto, SkillsModeManager.CurrentMode);
             Assert.IsFalse(EditorPrefs.HasKey(PrefKeyMode));
+        }
+
+        [Test]
+        public void ResetForTests_DomainReloadRecovery_RestoresExplicitBypassMode()
+        {
+            SkillsModeManager.CompleteTestPreferenceRecovery();
+            SkillsModeManager.CurrentMode = SkillsOperatingMode.Bypass;
+
+            SkillsModeManager.ResetForTests();
+            Assert.IsFalse(EditorPrefs.HasKey(PrefKeyMode));
+
+            SkillsModeManager.RestorePreferencesAfterTestDomainReload();
+
+            Assert.IsTrue(EditorPrefs.HasKey(PrefKeyMode));
+            Assert.AreEqual(SkillsOperatingMode.Bypass, SkillsModeManager.CurrentMode);
         }
 
         // ═════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem

An explicitly chosen operating mode silently reverts to **Auto** after a domain reload. The user picks **Bypass** in the panel, keeps working, and some time later — typically after a domain reload following a test run — the package is back in Auto and starts gating operations that were previously running unattended.

Nothing in the UI indicates the mode was reset, and the audit log shows no `mode_changed` event for the reversion, because no code ever *set* the mode back to Auto. The stored preference simply stopped existing.

## Root cause

`SkillsModeManager.ResetForTests()` gives each test a clean slate by deleting five **machine-wide** `EditorPrefs` keys — including `UnitySkills_OperatingMode`:

```csharp
EditorPrefs.DeleteKey(PrefKeyMode);
EditorPrefs.DeleteKey(PrefKeyPanelApproval);
EditorPrefs.DeleteKey(PrefKeyAllowlist);
EditorPrefs.DeleteKey(PrefKeyMigrationDone);
EditorPrefs.DeleteKey(PrefKeyLegacyGranted);
```

The fixtures are careful about this: they snapshot the real values in `[OneTimeSetUp]` and put them back in `[OneTimeTearDown]`. But `ResetForTests()` runs in both `[SetUp]` **and** `[TearDown]`, so the user's preferences are deleted for the *entire* duration of the fixture and are restored only by that single `[OneTimeTearDown]` at the very end.

That makes the recovery path fragile. If the run never reaches `[OneTimeTearDown]` — a domain reload triggered mid-run by a recompile or by a skill under test, a cancelled run, an aborted run — the key stays deleted, and the fixture's in-memory snapshot dies with the domain.

The reversion to **Auto** specifically comes from the no-key fallback in the `CurrentMode` getter:

```csharp
if (EditorPrefs.HasKey(PrefKeyMode)) { /* parse and return */ }
return IsExistingInstall() ? SkillsOperatingMode.Bypass : SkillsOperatingMode.Auto;
```

`IsExistingInstall()` is true only when one of seven legacy `UnitySkills_*` keys is present (`RequireConfirmation`, `PreferredPort`, `LogLevel`, `Language`, `RequestTimeoutMinutes`, `KeepAliveIntervalSeconds`, `AutoInstallPackagesOnStartup`). Those keys are written when the user changes the corresponding setting. A user who installed the package and never touched any of them has **none** of them, so the fallback resolves to `Auto` — and their deleted Bypass reads back as Auto. On a machine that happens to have one of those keys, the same deletion falls back to Bypass and the bug is invisible. This is why it reproduces on some setups and not others.

Two things widen the blast radius:

- `ResetForTests()` is the **only** production code path that deletes `UnitySkills_OperatingMode`, so this is the entire surface of the bug — but it is also entirely sufficient to cause it.
- Any project that lists `com.besty.unity-skills` in its `testables` runs these fixtures as part of its own EditMode suite. The user does not have to be developing the package to lose their mode; running their own project's tests is enough.

The same reasoning applies to the other four keys deleted alongside it — panel-approval preference, allowlist, migration flag, and the legacy granted-skills list.

## Fix

Add a recovery path that survives the domain reload that breaks the existing one.

1. **Capture** — `ResetForTests()` now writes the five preference values into `SessionState` before deleting them. `SessionState` survives domain reloads, which is precisely what the in-memory fixture snapshot does not do. The capture is guarded by an `Active` flag so only the *first* `ResetForTests()` of a session records values; the subsequent per-test calls do not overwrite the pristine snapshot with the already-wiped state.

2. **Restore** — `SkillsModeManager` is marked `[InitializeOnLoad]` and its new static constructor calls `RestorePreferencesAfterTestDomainReload()`. On every domain load, if the recovery flag is set, the saved values are written back — including correctly re-deleting keys that genuinely did not exist before the run — and the recovery data is cleared.

3. **Disarm** — each fixture's `[OneTimeTearDown]` calls `CompleteTestPreferenceRecovery()` *after* restoring its own snapshot. A clean run therefore clears the recovery data itself, so a later unrelated domain reload cannot resurrect stale values.

The net effect: on a clean run nothing changes, and on an interrupted run the user's preferences come back at the next domain reload instead of being lost.

`RestorePreferencesAfterTestDomainReload()` is exposed as `internal` so the regression test can drive the recovery step directly rather than having to provoke a real domain reload inside a test.

Cost outside of tests is one `SessionState.GetBool` per domain load.

## Test coverage

`ResetForTests_DomainReloadRecovery_RestoresExplicitBypassMode` covers the exact reported scenario: set Bypass explicitly, call `ResetForTests()`, assert the key is gone, then run the recovery that the static constructor would run after a reload, and assert the mode is Bypass again.

## Known limitations

- Recovery is keyed on `SessionState`, which does not survive an Editor **restart**. If the Editor crashes or is killed mid-run rather than merely reloading the domain, the preferences are still lost. Covering that would need a disk-backed sidecar; that seemed disproportionate for the failure mode.
- Recovery happens at the *next* domain reload. After a cancelled run, the mode reads as the fallback until then.

## Alternatives considered

The deeper fix is for `ResetForTests()` never to touch machine-wide `EditorPrefs` at all — routing mode/allowlist state through an injectable preference store, or namespacing the keys under a test-scoped prefix. That removes the failure mode instead of recovering from it, but it changes what the existing fixtures are actually asserting and touches every consumer of those keys. This PR is deliberately the narrow, behavior-preserving safety net; the isolation refactor is worth doing separately if you want it.

## Testing

- New regression test added; **not executed** — the Unity Editor on this machine is in use by unrelated work and running EditMode tests forces a domain reload.
- Verified statically on a live install instead: with the patch compiled into the Editor, `UnitySkills_OperatingMode` survives domain reloads intact, the new `[InitializeOnLoad]` static constructor raises no type-initialization error, and skill execution continues to run with Bypass semantics.
- Note that the install used for that check predates this PR's base branch, so only the `SkillsModeManager.cs` change and the `SkillsModeManagerTests.cs` change were exercised there; the two other fixture teardowns were not.

CI on `beta` is the authoritative check for this one.
